### PR TITLE
Geting apptags

### DIFF
--- a/vogue/adapter/plugin.py
+++ b/vogue/adapter/plugin.py
@@ -16,6 +16,7 @@ class VougeAdapter(MongoAdapter):
         self.db_name = db_name
         self.sample_collection = self.db.sample
         self.analysis_collection = self.db.analysis
+        self.app_tag_collection = self.db.application_tag
         
         LOG.info(f"Use database {db_name}.")
 
@@ -38,6 +39,14 @@ class VougeAdapter(MongoAdapter):
 
     def sample(self, lims_id):
         return self.sample_collection.find_one({'_id':lims_id})
+
+    def app_tag(self, app_tag):
+        return self.app_tag_collection.find_one({'_id':app_tag})
+
+    def find_app_tags(self, query:dict)-> list:
+        app_tags = self.app_tag_collection.find(query)
+        return list(app_tags)
+    
 
     def delete_sample(self):
         return None

--- a/vogue/adapter/plugin.py
+++ b/vogue/adapter/plugin.py
@@ -40,14 +40,6 @@ class VougeAdapter(MongoAdapter):
     def sample(self, lims_id):
         return self.sample_collection.find_one({'_id':lims_id})
 
-    def app_tag(self, app_tag):
-        return self.app_tag_collection.find_one({'_id':app_tag})
-
-    def find_app_tags(self, query:dict)-> list:
-        app_tags = self.app_tag_collection.find(query)
-        return list(app_tags)
-    
-
     def delete_sample(self):
         return None
 

--- a/vogue/server/templates/samples.html
+++ b/vogue/server/templates/samples.html
@@ -26,7 +26,7 @@
 
     Highcharts.chart('received', {
         chart: { type: 'areaspline' },
-        title: { text: {{ received_application.title | tojson }} },
+        title: { text: {{ received.title | tojson }} },
         xAxis: { categories: {{ received.labels| tojson }}},
         yAxis: { title: { text: {{ received.axis.y | tojson }} } },
         tooltip: {

--- a/vogue/server/templates/turn_around_times.html
+++ b/vogue/server/templates/turn_around_times.html
@@ -6,34 +6,41 @@
         <main role="main" class="col-md-9 ml-sm-auto col-lg-10 px-4">
             {% include 'header_section.html' %}
             <div class="row">
-                <div class="col-lg-6" , id='received_to_delivered'></div>
-                <div class="col-lg-6" id="received_to_prepped"></div>
+                <div class="col-lg-6" , id='received_to_delivered_tag'></div>
+                <div class="col-lg-6" , id='received_to_delivered_prio'></div>
             </div>
             <div class="row">
-                <div class="col-lg-6" id="prepped_to_sequenced"></div>
-                <div class="col-lg-6" id="sequenced_to_delivered"></div>
+                    <div class="col-lg-6" id="received_to_prepped_tag"></div>
+                    <div class="col-lg-6" id="received_to_prepped_prio"></div>
             </div>
-
+            <div class="row">
+                    <div class="col-lg-6" id="prepped_to_sequenced_tag"></div>
+                    <div class="col-lg-6" id="prepped_to_sequenced_prio"></div>
+            </div>
+            <div class="row">
+                    <div class="col-lg-6" id="sequenced_to_delivered_tag"></div>
+                    <div class="col-lg-6" id="sequenced_to_delivered_prio"></div>
+            </div>
         </main>
     </div>
 </div>
 
 <script>
     var series = []
-    {% for name in sequenced_to_delivered.group %}
+    {% for name in sequenced_to_delivered.prio.group %}
     series.push({
         name: "{{name}}",
-        data: {{ sequenced_to_delivered.group[name].data | tojson }},
-        color: "{{sequenced_to_delivered.group[name].color[0]}}",
+        data: {{ sequenced_to_delivered.prio.group[name].data | tojson }},
+        color: "{{sequenced_to_delivered.prio.group[name].color[0]}}",
         marker: { symbol: 'circle' },
-        fillColor: "{{sequenced_to_delivered.group[name].color[1]}}"})
+        fillColor: "{{sequenced_to_delivered.prio.group[name].color[1]}}"})
     {% endfor %}
 
-    Highcharts.chart('sequenced_to_delivered', {
+    Highcharts.chart('sequenced_to_delivered_prio', {
         chart: { type: 'areaspline' },
-        title: { text: {{ sequenced_to_delivered.title| tojson }}},
-        xAxis: { categories: {{ sequenced_to_delivered.labels| tojson }}},
-        yAxis: { title: { text: {{ sequenced_to_delivered.axis.y | tojson }}}},
+        title: { text: {{ sequenced_to_delivered.prio.title| tojson }}},
+        xAxis: { categories: {{ sequenced_to_delivered.prio.labels| tojson }}},
+        yAxis: { title: { text: {{ sequenced_to_delivered.prio.axis.y | tojson }}}},
         tooltip: {
             shared: true,
             valueSuffix: ' days'
@@ -42,20 +49,20 @@
 
 
     var series = []
-    {% for name in prepped_to_sequenced.group %}
+    {% for name in prepped_to_sequenced.prio.group %}
     series.push({
         name: "{{name}}",
-        data: {{ prepped_to_sequenced.group[name].data | tojson }},
-        color: "{{prepped_to_sequenced.group[name].color[0]}}",
+        data: {{ prepped_to_sequenced.prio.group[name].data | tojson }},
+        color: "{{prepped_to_sequenced.prio.group[name].color[0]}}",
         marker: { symbol: 'circle' },
-        fillColor: "{{prepped_to_sequenced.group[name].color[1]}}"})
+        fillColor: "{{prepped_to_sequenced.prio.group[name].color[1]}}"})
     {% endfor %}
 
-    Highcharts.chart('prepped_to_sequenced', {
+    Highcharts.chart('prepped_to_sequenced_prio', {
         chart: { type: 'areaspline' },
-        title: { text: {{ prepped_to_sequenced.title| tojson }}},
-        xAxis: { categories: {{ prepped_to_sequenced.labels| tojson }}},
-        yAxis: { title: { text: {{ prepped_to_sequenced.axis.y | tojson }}}},
+        title: { text: {{ prepped_to_sequenced.prio.title| tojson }}},
+        xAxis: { categories: {{ prepped_to_sequenced.prio.labels| tojson }}},
+        yAxis: { title: { text: {{ prepped_to_sequenced.prio.axis.y | tojson }}}},
         tooltip: {
             shared: true,
             valueSuffix: ' days'
@@ -63,20 +70,20 @@
         series: series});
 
     var series = []
-    {% for name in received_to_prepped.group %}
+    {% for name in received_to_prepped.prio.group %}
     series.push({
         name: "{{name}}",
-        data: {{ received_to_prepped.group[name].data | tojson }},
-        color: "{{received_to_prepped.group[name].color[0]}}",
+        data: {{ received_to_prepped.prio.group[name].data | tojson }},
+        color: "{{received_to_prepped.prio.group[name].color[0]}}",
         marker: { symbol: 'circle' },
-        fillColor: "{{received_to_prepped.group[name].color[1]}}"})
+        fillColor: "{{received_to_prepped.prio.group[name].color[1]}}"})
     {% endfor %}
 
-    Highcharts.chart('received_to_prepped', {
+    Highcharts.chart('received_to_prepped_prio', {
         chart: { type: 'areaspline' },
-        title: { text: {{ received_to_prepped.title| tojson }}},
-        xAxis: { categories: {{ received_to_prepped.labels| tojson }}},
-        yAxis: { title: { text: {{ received_to_prepped.axis.y | tojson }}}},
+        title: { text: {{ received_to_prepped.prio.title| tojson }}},
+        xAxis: { categories: {{ received_to_prepped.prio.labels| tojson }}},
+        yAxis: { title: { text: {{ received_to_prepped.prio.axis.y | tojson }}}},
         tooltip: {
             shared: true,
             valueSuffix: ' days'
@@ -84,25 +91,112 @@
         series: series});
 
     var series = []
-    {% for name in received_to_delivered.group %}
+    {% for name in received_to_delivered.prio.group %}
     series.push({
         name: "{{name}}",
-        data: {{ received_to_delivered.group[name].data | tojson }},
-        color: "{{received_to_delivered.group[name].color[0]}}",
+        data: {{ received_to_delivered.prio.group[name].data | tojson }},
+        color: "{{received_to_delivered.prio.group[name].color[0]}}",
         marker: { symbol: 'circle' },
-        fillColor: "{{received_to_delivered.group[name].color[1]}}"})
+        fillColor: "{{received_to_delivered.prio.group[name].color[1]}}"})
     {% endfor %}
 
-    Highcharts.chart('received_to_delivered', {
+    Highcharts.chart('received_to_delivered_prio', {
         chart: { type: 'areaspline' },
-        title: { text: {{ received_to_delivered.title| tojson }}},
-        xAxis: { categories: {{ received_to_delivered.labels| tojson }}},
-        yAxis: { title: { text: {{ received_to_delivered.axis.y | tojson }}}},
+        title: { text: {{ received_to_delivered.prio.title| tojson }}},
+        xAxis: { categories: {{ received_to_delivered.prio.labels| tojson }}},
+        yAxis: { title: { text: {{ received_to_delivered.prio.axis.y | tojson }}}},
         tooltip: {
             shared: true,
             valueSuffix: ' days'
         },
         series: series});
 
+
+
+
+    var series = []
+    {% for name in sequenced_to_delivered.tag.group %}
+    series.push({
+        name: "{{name}}",
+        data: {{ sequenced_to_delivered.tag.group[name].data | tojson }},
+        color: "{{sequenced_to_delivered.tag.group[name].color[0]}}",
+        marker: { symbol: 'circle' },
+        fillColor: "{{sequenced_to_delivered.tag.group[name].color[1]}}"})
+    {% endfor %}
+
+    Highcharts.chart('sequenced_to_delivered_tag', {
+        chart: { type: 'areaspline' },
+        title: { text: {{ sequenced_to_delivered.tag.title| tojson }}},
+        xAxis: { categories: {{ sequenced_to_delivered.tag.labels| tojson }}},
+        yAxis: { title: { text: {{ sequenced_to_delivered.tag.axis.y | tojson }}}},
+        tooltip: {
+            shared: true,
+            valueSuffix: ' days'
+        },
+        series: series});
+
+
+    var series = []
+    {% for name in prepped_to_sequenced.tag.group %}
+    series.push({
+        name: "{{name}}",
+        data: {{ prepped_to_sequenced.tag.group[name].data | tojson }},
+        color: "{{prepped_to_sequenced.tag.group[name].color[0]}}",
+        marker: { symbol: 'circle' },
+        fillColor: "{{prepped_to_sequenced.tag.group[name].color[1]}}"})
+    {% endfor %}
+
+    Highcharts.chart('prepped_to_sequenced_tag', {
+        chart: { type: 'areaspline' },
+        title: { text: {{ prepped_to_sequenced.tag.title| tojson }}},
+        xAxis: { categories: {{ prepped_to_sequenced.tag.labels| tojson }}},
+        yAxis: { title: { text: {{ prepped_to_sequenced.tag.axis.y | tojson }}}},
+        tooltip: {
+            shared: true,
+            valueSuffix: ' days'
+        },
+        series: series});
+
+    var series = []
+    {% for name in received_to_prepped.tag.group %}
+    series.push({
+        name: "{{name}}",
+        data: {{ received_to_prepped.tag.group[name].data | tojson }},
+        color: "{{received_to_prepped.tag.group[name].color[0]}}",
+        marker: { symbol: 'circle' },
+        fillColor: "{{received_to_prepped.tag.group[name].color[1]}}"})
+    {% endfor %}
+
+    Highcharts.chart('received_to_prepped_tag', {
+        chart: { type: 'areaspline' },
+        title: { text: {{ received_to_prepped.tag.title| tojson }}},
+        xAxis: { categories: {{ received_to_prepped.tag.labels| tojson }}},
+        yAxis: { title: { text: {{ received_to_prepped.tag.axis.y | tojson }}}},
+        tooltip: {
+            shared: true,
+            valueSuffix: ' days'
+        },
+        series: series});
+
+    var series = []
+    {% for name in received_to_delivered.tag.group %}
+    series.push({
+        name: "{{name}}",
+        data: {{ received_to_delivered.tag.group[name].data | tojson }},
+        color: "{{received_to_delivered.tag.group[name].color[0]}}",
+        marker: { symbol: 'circle' },
+        fillColor: "{{received_to_delivered.tag.group[name].color[1]}}"})
+    {% endfor %}
+
+    Highcharts.chart('received_to_delivered_tag', {
+        chart: { type: 'areaspline' },
+        title: { text: {{ received_to_delivered.tag.title| tojson }}},
+        xAxis: { categories: {{ received_to_delivered.tag.labels| tojson }}},
+        yAxis: { title: { text: {{ received_to_delivered.tag.axis.y | tojson }}}},
+        tooltip: {
+            shared: true,
+            valueSuffix: ' days'
+        },
+        series: series});
 </script>
 {% endblock %}

--- a/vogue/server/utils.py
+++ b/vogue/server/utils.py
@@ -89,33 +89,36 @@ def find_key_over_time( title: str, year : int, y_axis_label: str, y_unit : str,
 
     The "time" is allways in months and the "something" can be either number of samples of a 
     certain group, or the average of some value from all samples within a certain group.
-    If no group_queries is provided, all samples will be concidered as one group.
+    If no group_queries are provided, all samples will be concidered as one group.
 
     Args:
-        title :         Plot title.
-        year :          Data from this year will be shown in the plot.
-                        example: 2018
+        title : Plot title.
+        year :  Data from this year will be shown in the plot.
+                example: 2018
         group_queries : List of tuples (<group name>, <group query>)
-                        example: 
-        y_axis_key :    Key in database wich value will be plotted on the Y-axes (if given).
-                        example:
-        y_unit :        Determines what to plot on the y axis (average/nr samples) (if "nr samples", 
-                        no y_axis_key is needed).
-        y_axis_label :  What it seems to be :)
+                examples:   ('wgs', {'application_tag': {'$in': ['WGSPCFC030', 'WGSPCFC060',...]})
+                            ('standard', {'priority': {'$eq': 'standard'}})
+        y_axis_key : Key in database wich value will be plotted on the Y-axes (if given).
+                example: 'sequenced_to_delivered'
+        y_unit : Determines what to plot on the y axis (average/nr samples) (if "nr samples", no 
+                y_axis_key is needed).
+        y_axis_label : What it seems to be :)
 
-    Returns:
-        plot_content:   {'axis' : {'y': 'Days'}, 
-                        'title' : 'Time from recieved to delivered (grouped by application tag)', 
-                        'labels' : ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-                        'group' : {'rml': {'data': [3.0, 4.6, 6.3, 3.6, 3.3, 3.4, 3.2, 3.3, 4.5, 4.6, 3.7, 9.2], 
-                                           'color': ('RGB(255, 0, 0)', 'RGB(255, 0, 0, 0.2)')}, 
-                                   'wes': {'data': [None, None, None, 83.0, None, 9.0, None, None, None, None, None, None], 
-                                           'color': ('RGB(128, 0, 128)', 'RGB(128, 0, 128, 0.2)')}, 
-                                   'tga': {'data': [None, 13.2, 18.0, 16.6, None, None, None, None, None, None, None, None], 
-                                           'color': ('RGB(128, 0, 0)', 'RGB(128, 0, 0,0.2)')}, 
-                                   'wgs': {'data': [12.6, 13.0, 11.6, 15.3, 16.4, 12.1, 12.7, 13.4, 38.8, 12.0, 14.2, 28.1], 
-                                           'color': ('RGB(128, 128, 0)', 'RGB(128, 128, 0,0.2)')}} 
-                                            }
+    Returns: 
+        Dict with data needed to generate the plot.  
+        example: 
+        
+        {'axis' : {'y': 'Days'}, 
+        'title' : 'Time from recieved to delivered (grouped by application tag)', 
+        'labels' : ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+        'group' :  {'rml': {'data': [3.0, 4.6, 6.3, 3.6, 3.3, 3.4, 3.2, 3.3, 4.5, 4.6, 3.7, 9.2], 
+                            'color': ('RGB(255, 0, 0)', 'RGB(255, 0, 0, 0.2)')}, 
+                    'wes': {'data': [None, None, None, 83.0, None, 9.0, None, None, None, None, None, None], 
+                            'color': ('RGB(128, 0, 128)', 'RGB(128, 0, 128, 0.2)')}, 
+                    'tga': {'data': [None, 13.2, 18.0, 16.6, None, None, None, None, None, None, None, None], 
+                            'color': ('RGB(128, 0, 0)', 'RGB(128, 0, 0,0.2)')}, 
+                    'wgs': {'data': [12.6, 13.0, 11.6, 15.3, 16.4, 12.1, 12.7, 13.4, 38.8, 12.0, 14.2, 28.1], 
+                            'color': ('RGB(128, 128, 0)', 'RGB(128, 128, 0,0.2)')}}}
         """
 
     plot_content = {'axis' : {'y' : y_axis_label}, 

--- a/vogue/server/utils.py
+++ b/vogue/server/utils.py
@@ -59,7 +59,7 @@ def get_percentiles(samples: list, key: str)-> float:
 
     return percentiles
 
-def build_app_tag_group_queries()-> dict:
+def build_app_tag_group_queries()-> list:
     """Returns List of tuples (<group name>, <group query>), 
         <group name>        the app tag category (wgs, rml, etc) 
         <group query>       the query for all app tags in the category"""
@@ -82,9 +82,8 @@ def build_group_queries_from_key(group_key)-> list:
     return queries
 
 
-def find_key_over_time( title: str = None, year : int = None, group_queries: list = [('no_group',{})], 
-                        y_axis_key: str = None, y_axis_label: str = None, y_unit : str = None, 
-                        adapter = adapter)-> dict:
+def find_key_over_time( title: str, year : int, y_axis_label: str, y_unit : str, adapter = adapter, 
+                        group_queries: list = [('no_group',{})], y_axis_key: str=None)-> dict:
 
     """Prepares data for plots showing progress of "something" over "time".
 
@@ -92,14 +91,31 @@ def find_key_over_time( title: str = None, year : int = None, group_queries: lis
     certain group, or the average of some value from all samples within a certain group.
     If no group_queries is provided, all samples will be concidered as one group.
 
-    Input:
+    Args:
         title :         Plot title.
-        year :          Data from this year will be shown in the plot. 
+        year :          Data from this year will be shown in the plot.
+                        example: 2018
         group_queries : List of tuples (<group name>, <group query>)
+                        example: 
         y_axis_key :    Key in database wich value will be plotted on the Y-axes (if given).
+                        example:
         y_unit :        Determines what to plot on the y axis (average/nr samples) (if "nr samples", 
                         no y_axis_key is needed).
         y_axis_label :  What it seems to be :)
+
+    Returns:
+        plot_content:   {'axis' : {'y': 'Days'}, 
+                        'title' : 'Time from recieved to delivered (grouped by application tag)', 
+                        'labels' : ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+                        'group' : {'rml': {'data': [3.0, 4.6, 6.3, 3.6, 3.3, 3.4, 3.2, 3.3, 4.5, 4.6, 3.7, 9.2], 
+                                           'color': ('RGB(255, 0, 0)', 'RGB(255, 0, 0, 0.2)')}, 
+                                   'wes': {'data': [None, None, None, 83.0, None, 9.0, None, None, None, None, None, None], 
+                                           'color': ('RGB(128, 0, 128)', 'RGB(128, 0, 128, 0.2)')}, 
+                                   'tga': {'data': [None, 13.2, 18.0, 16.6, None, None, None, None, None, None, None, None], 
+                                           'color': ('RGB(128, 0, 0)', 'RGB(128, 0, 0,0.2)')}, 
+                                   'wgs': {'data': [12.6, 13.0, 11.6, 15.3, 16.4, 12.1, 12.7, 13.4, 38.8, 12.0, 14.2, 28.1], 
+                                           'color': ('RGB(128, 128, 0)', 'RGB(128, 128, 0,0.2)')}} 
+                                            }
         """
 
     plot_content = {'axis' : {'y' : y_axis_label}, 
@@ -131,7 +147,6 @@ def find_key_over_time( title: str = None, year : int = None, group_queries: lis
 
         if list(set(data)) != [None]:
             plot_content['group'][group] = {'data' : data, 'color' : COLORS[i]}
-
     return plot_content
 
 

--- a/vogue/server/views.py
+++ b/vogue/server/views.py
@@ -3,7 +3,8 @@ from vogue.constants.constants import YEARS, THIS_YEAR
 
 from extentions import app
 from vogue.server.utils import ( find_concentration_defrosts, find_concentration_amount,   
-                                find_key_over_time)
+                                find_key_over_time, build_group_queries_from_key, 
+                                build_app_tag_group_queries)
 
 @app.route('/', methods=['GET', 'POST'])
 def index():
@@ -32,35 +33,65 @@ def index():
 
 @app.route('/common/turn_around_times/<year_of_interest>')
 def turn_around_times(year_of_interest):
-    group_key = "priority"
-    received_to_delivered = find_key_over_time(
+    app_tag_group_queries = build_app_tag_group_queries()
+    prio_group_queries = build_group_queries_from_key("priority")
+
+    received_to_delivered = {'tag' : find_key_over_time(
                                 year = year_of_interest, 
-                                group_key = group_key, 
+                                group_queries = app_tag_group_queries, 
                                 y_axis_key ='received_to_delivered', 
-                                title = 'Time from recieved to delivered', 
+                                title = 'Time from recieved to delivered (grouped by application tag)', 
                                 y_axis_label = 'Days', 
-                                y_unit = 'average')
-    received_to_prepped = find_key_over_time(
+                                y_unit = 'average'),
+                            'prio' : find_key_over_time(
                                 year = year_of_interest, 
-                                group_key = group_key, 
+                                group_queries = prio_group_queries, 
+                                y_axis_key ='received_to_delivered', 
+                                title = 'Time from recieved to delivered (grouped by priority)', 
+                                y_axis_label = 'Days', 
+                                y_unit = 'average')}
+    received_to_prepped = {'tag' : find_key_over_time(
+                                year = year_of_interest, 
+                                group_queries = app_tag_group_queries, 
                                 y_axis_key ='received_to_prepped' , 
-                                title = 'Time from recieved to prepped', 
+                                title = 'Time from recieved to prepped (grouped by application tag)', 
                                 y_axis_label = 'Days', 
-                                y_unit = 'average')
-    prepped_to_sequenced = find_key_over_time(
+                                y_unit = 'average'),
+                            'prio' : find_key_over_time(
                                 year = year_of_interest, 
-                                group_key = group_key, 
+                                group_queries = prio_group_queries, 
+                                y_axis_key ='received_to_prepped' , 
+                                title = 'Time from recieved to prepped (grouped by priority)', 
+                                y_axis_label = 'Days', 
+                                y_unit = 'average')}
+    prepped_to_sequenced = {'tag' : find_key_over_time(
+                                year = year_of_interest, 
+                                group_queries = app_tag_group_queries, 
                                 y_axis_key ='prepped_to_sequenced' , 
-                                title = 'Time from prepped to sequenced', 
+                                title = 'Time from prepped to sequenced (grouped by application tag)', 
                                 y_axis_label = 'Days', 
-                                y_unit = 'average')
-    sequenced_to_delivered = find_key_over_time(
+                                y_unit = 'average'),
+                            'prio' : find_key_over_time(
                                 year = year_of_interest, 
-                                group_key = group_key, 
-                                y_axis_key ='sequenced_to_delivered', 
-                                title = 'Time from sequenced to delivered', 
+                                group_queries = prio_group_queries, 
+                                y_axis_key ='prepped_to_sequenced' , 
+                                title = 'Time from prepped to sequenced (grouped by priority)', 
                                 y_axis_label = 'Days', 
-                                y_unit = 'average')
+                                y_unit = 'average')}
+    sequenced_to_delivered = {'tag' : find_key_over_time(
+                                year = year_of_interest, 
+                                group_queries = app_tag_group_queries, 
+                                y_axis_key ='sequenced_to_delivered', 
+                                title = 'Time from sequenced to delivered (grouped by application tag)', 
+                                y_axis_label = 'Days', 
+                                y_unit = 'average'),
+                            'prio' : find_key_over_time(
+                                year = year_of_interest, 
+                                group_queries = prio_group_queries, 
+                                y_axis_key ='sequenced_to_delivered', 
+                                title = 'Time from sequenced to delivered (grouped by priority)', 
+                                y_axis_label = 'Days', 
+                                y_unit = 'average')}
     
     return render_template('turn_around_times.html',
         header = 'Turn Around Times',
@@ -76,17 +107,18 @@ def turn_around_times(year_of_interest):
 @app.route('/common/samples/<year_of_interest>')
 def common_samples(year_of_interest):
     group_by = ['research','standard','priority']#,'express']
-    group_key = "priority"
+    group_queries = build_group_queries_from_key("priority")
+    app_tag_group_queries = build_app_tag_group_queries()
     received = find_key_over_time(
                     year = year_of_interest, 
-                    group_key = group_key, 
+                    group_queries = group_queries, 
                     title = 'Received_application samples per month (grouped by priority)', 
                     y_axis_label = 'Nr of samples', 
                     y_unit = 'number samples')
     received_application = find_key_over_time(
                     year = year_of_interest, 
-                    group_key = group_key, 
-                    title = 'Received_application samples per month (grouped by priority)', 
+                    group_queries = app_tag_group_queries, 
+                    title = 'Received_application samples per month (grouped by aplication tag)', 
                     y_axis_label = 'Days', 
                     y_unit = 'number samples')#wrong groups!!!
 
@@ -101,9 +133,10 @@ def common_samples(year_of_interest):
 
 @app.route('/prepps/microbial/<year_of_interest>')
 def microbial(year_of_interest):
+    group_queries = build_group_queries_from_key("strain")
     microbial_concentration_time = find_key_over_time(
                                         year = year_of_interest, 
-                                        group_key = 'strain', 
+                                        group_queries = group_queries, 
                                         y_axis_key ='microbial_library_concentration', 
                                         title = 'Microbial',
                                         y_axis_label = 'Concentration (nM)',
@@ -119,16 +152,17 @@ def microbial(year_of_interest):
 
 @app.route('/prepps/target_enrichment/<year_of_interest>')
 def target_enrichment(year_of_interest):
+    group_queries = build_group_queries_from_key("source")
     library_size_post_hyb = find_key_over_time(
                                 year = year_of_interest, 
-                                group_key = 'source', 
+                                group_queries = group_queries, 
                                 y_axis_key ='library_size_post_hyb', 
                                 title = 'Post-hybridization QC', 
                                 y_axis_label = 'library size',
                                 y_unit = 'average')
     library_size_pre_hyb = find_key_over_time(
                                 year = year_of_interest, 
-                                group_key = 'source', 
+                                group_queries = group_queries, 
                                 y_axis_key ='library_size_pre_hyb', 
                                 title = 'Pre-hybridization QC', 
                                 y_axis_label = 'library size',

--- a/vogue/server/views.py
+++ b/vogue/server/views.py
@@ -33,61 +33,60 @@ def index():
 
 @app.route('/common/turn_around_times/<year_of_interest>')
 def turn_around_times(year_of_interest):
-    app_tag_group_queries = build_app_tag_group_queries()
-    prio_group_queries = build_group_queries_from_key("priority")
+
 
     received_to_delivered = {'tag' : find_key_over_time(
                                 year = year_of_interest, 
-                                group_queries = app_tag_group_queries, 
+                                group_queries = build_app_tag_group_queries(), 
                                 y_axis_key ='received_to_delivered', 
                                 title = 'Time from recieved to delivered (grouped by application tag)', 
                                 y_axis_label = 'Days', 
                                 y_unit = 'average'),
                             'prio' : find_key_over_time(
                                 year = year_of_interest, 
-                                group_queries = prio_group_queries, 
+                                group_queries = build_group_queries_from_key("priority"), 
                                 y_axis_key ='received_to_delivered', 
                                 title = 'Time from recieved to delivered (grouped by priority)', 
                                 y_axis_label = 'Days', 
                                 y_unit = 'average')}
     received_to_prepped = {'tag' : find_key_over_time(
                                 year = year_of_interest, 
-                                group_queries = app_tag_group_queries, 
+                                group_queries = build_app_tag_group_queries(), 
                                 y_axis_key ='received_to_prepped' , 
                                 title = 'Time from recieved to prepped (grouped by application tag)', 
                                 y_axis_label = 'Days', 
                                 y_unit = 'average'),
                             'prio' : find_key_over_time(
                                 year = year_of_interest, 
-                                group_queries = prio_group_queries, 
+                                group_queries = build_group_queries_from_key("priority"), 
                                 y_axis_key ='received_to_prepped' , 
                                 title = 'Time from recieved to prepped (grouped by priority)', 
                                 y_axis_label = 'Days', 
                                 y_unit = 'average')}
     prepped_to_sequenced = {'tag' : find_key_over_time(
                                 year = year_of_interest, 
-                                group_queries = app_tag_group_queries, 
+                                group_queries = build_app_tag_group_queries(), 
                                 y_axis_key ='prepped_to_sequenced' , 
                                 title = 'Time from prepped to sequenced (grouped by application tag)', 
                                 y_axis_label = 'Days', 
                                 y_unit = 'average'),
                             'prio' : find_key_over_time(
                                 year = year_of_interest, 
-                                group_queries = prio_group_queries, 
+                                group_queries = build_group_queries_from_key("priority"), 
                                 y_axis_key ='prepped_to_sequenced' , 
                                 title = 'Time from prepped to sequenced (grouped by priority)', 
                                 y_axis_label = 'Days', 
                                 y_unit = 'average')}
     sequenced_to_delivered = {'tag' : find_key_over_time(
                                 year = year_of_interest, 
-                                group_queries = app_tag_group_queries, 
+                                group_queries = build_app_tag_group_queries(), 
                                 y_axis_key ='sequenced_to_delivered', 
                                 title = 'Time from sequenced to delivered (grouped by application tag)', 
                                 y_axis_label = 'Days', 
                                 y_unit = 'average'),
                             'prio' : find_key_over_time(
                                 year = year_of_interest, 
-                                group_queries = prio_group_queries, 
+                                group_queries = build_group_queries_from_key("priority"), 
                                 y_axis_key ='sequenced_to_delivered', 
                                 title = 'Time from sequenced to delivered (grouped by priority)', 
                                 y_axis_label = 'Days', 
@@ -112,15 +111,15 @@ def common_samples(year_of_interest):
     received = find_key_over_time(
                     year = year_of_interest, 
                     group_queries = group_queries, 
-                    title = 'Received_application samples per month (grouped by priority)', 
+                    title = 'Received samples per month (grouped by priority)', 
                     y_axis_label = 'Nr of samples', 
                     y_unit = 'number samples')
     received_application = find_key_over_time(
                     year = year_of_interest, 
                     group_queries = app_tag_group_queries, 
-                    title = 'Received_application samples per month (grouped by aplication tag)', 
-                    y_axis_label = 'Days', 
-                    y_unit = 'number samples')#wrong groups!!!
+                    title = 'Received samples per month (grouped by aplication tag)', 
+                    y_axis_label = 'Nr of samples', 
+                    y_unit = 'number samples')
 
     return render_template('samples.html',
         header = 'Samples',
@@ -152,17 +151,16 @@ def microbial(year_of_interest):
 
 @app.route('/prepps/target_enrichment/<year_of_interest>')
 def target_enrichment(year_of_interest):
-    group_queries = build_group_queries_from_key("source")
     library_size_post_hyb = find_key_over_time(
                                 year = year_of_interest, 
-                                group_queries = group_queries, 
+                                group_queries = build_group_queries_from_key("source"), 
                                 y_axis_key ='library_size_post_hyb', 
                                 title = 'Post-hybridization QC', 
                                 y_axis_label = 'library size',
                                 y_unit = 'average')
     library_size_pre_hyb = find_key_over_time(
                                 year = year_of_interest, 
-                                group_queries = group_queries, 
+                                group_queries = build_group_queries_from_key("source"), 
                                 y_axis_key ='library_size_pre_hyb', 
                                 title = 'Pre-hybridization QC', 
                                 y_axis_label = 'library size',
@@ -185,7 +183,7 @@ def wgs(year_of_interest):
                             y_axis_key ='nr_defrosts-concentration', 
                             title = 'wgs illumina PCR-free', 
                             y_axis_label = 'Concentration (nM)',
-                            y_unit = 'average') #, by_month=False)
+                            y_unit = 'average')
     return render_template('wgs.html',
         header = 'WGS illumina PCR-free',
         page_id = 'wgs',


### PR DESCRIPTION
Front end adjustments based on the new application tag collection.

In some plots, samples are supposed to be grouped by application tag category. The application tag category is hold by the new application tag collection.

This PR contains the front end adjustments to make this happen. 

The most crucial changes are in utils.py where i added two new functions to create two types of "group_by_queries" The output of these are then passed to the find_key_over_time() function through the new argument "group_queries".

