### PR TITLE
Create MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include vogue/constants *


### PR DESCRIPTION
For some reason, vogue.constants is ignored when pip installing, so I've put it in the MANIFEST