### PR TITLE
Add __init__.py in constants dir

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-recursive-include vogue/constants *


### PR DESCRIPTION
Permanent fix for constants not being pip installed.