### PR TITLE
Bulk load multiqc raw data into a new collection

### DIFF
--- a/vogue/adapter/plugin.py
+++ b/vogue/adapter/plugin.py
@@ -16,6 +16,7 @@ class VougeAdapter(MongoAdapter):
         self.db_name = db_name
         self.sample_collection = self.db.sample
         self.sample_analysis_collection = self.db.sample_analysis
+        self.case_analysis_collection = self.db.case_analysis
         self.app_tag_collection = self.db.application_tag
         self.flowcell_collection = self.db.flowcell
         
@@ -83,7 +84,7 @@ class VougeAdapter(MongoAdapter):
     def delete_sample(self):
         return None
 
-    def add_or_update_analysis(self, analysis_result: dict):
+    def add_or_update_analysis_sample(self, analysis_result: dict):
         """Functionality to add or update analysis sample"""
         lims_id = analysis_result['_id']
         # pop _id key to make pushing easier
@@ -99,9 +100,30 @@ class VougeAdapter(MongoAdapter):
                     {'$set': {**analysis_result, **{'updated': dt.today()}}}, upsert=True)
             LOG.info("Updated analysis for sample %s.", lims_id)
 
-    def analysis(self, analysis_id: str):
+    def add_or_update_analysis_case(self, analysis_result: dict):
+        """Functionality to add or update analysis sample"""
+        case_id = analysis_result['_id']
+        print(case_id)
+        # pop _id key to make pushing easier
+        analysis_result.pop('_id')
+        update_result = self.db.case_analysis.find_one({'_id': case_id})
+
+        if update_result is None:
+            self.db.case_analysis.update_one({'_id' : case_id}, 
+                    {'$set': {**analysis_result, **{'added': dt.today()}}}, upsert=True)
+            LOG.info("Added analysis sample %s.", case_id)
+        else:
+            self.db.case_analysis.update_one({'_id' : case_id}, 
+                    {'$set': {**analysis_result, **{'updated': dt.today()}}}, upsert=True)
+            LOG.info("Updated analysis for sample %s.", case_id)
+
+    def sample_analysis(self, analysis_id: str):
         """Functionality to get analyses results"""
         return self.sample_analysis_collection.find_one({'_id':analysis_id})
+
+    def case_analysis(self, analysis_id: str):
+        """Functionality to get analyses results"""
+        return self.case_analysis_collection.find_one({'_id':analysis_id})
         
     def find_samples(self, query:dict)-> list:
         """Function to find samples in samples collection based on query"""

--- a/vogue/adapter/plugin.py
+++ b/vogue/adapter/plugin.py
@@ -134,7 +134,6 @@ class VougeAdapter(MongoAdapter):
     def add_or_update_analysis_case(self, analysis_result: dict):
         """Functionality to add or update analysis sample"""
         case_id = analysis_result['_id']
-        print(case_id)
         # pop _id key to make pushing easier
         analysis_result.pop('_id')
         update_result = self.db.case_analysis.find_one({'_id': case_id})

--- a/vogue/adapter/plugin.py
+++ b/vogue/adapter/plugin.py
@@ -6,8 +6,7 @@ LOG = logging.getLogger(__name__)
 
 
 class VougeAdapter(MongoAdapter):
-
-    def setup(self, db_name : str):
+    def setup(self, db_name: str):
         """Setup connection to a database"""
 
         if self.client is None:
@@ -19,22 +18,28 @@ class VougeAdapter(MongoAdapter):
         self.case_analysis_collection = self.db.case_analysis
         self.app_tag_collection = self.db.application_tag
         self.flowcell_collection = self.db.flowcell
-        
+
         LOG.info("Use database %s.", db_name)
 
     def add_or_update_sample(self, sample_news: dict):
         """Adds/updates a sample in the database"""
 
         lims_id = sample_news['_id']
-        update_result = self.db.sample.update_one({'_id' : lims_id}, {'$set': sample_news}, upsert=True)
+        update_result = self.db.sample.update_one({'_id': lims_id},
+                                                  {'$set': sample_news},
+                                                  upsert=True)
 
         if not update_result.raw_result['updatedExisting']:
-            self.db.sample.update_one({'_id' : lims_id}, 
-                {'$set': {'added': dt.today()}})
+            self.db.sample.update_one({'_id': lims_id},
+                                      {'$set': {
+                                          'added': dt.today()
+                                      }})
             LOG.info("Added sample %s.", lims_id)
         elif update_result.modified_count:
-            self.db.sample.update_one({'_id' : lims_id}, 
-                {'$set': {'updated': dt.today()}})
+            self.db.sample.update_one({'_id': lims_id},
+                                      {'$set': {
+                                          'updated': dt.today()
+                                      }})
             LOG.info("Updated sample %s.", lims_id)
         else:
             LOG.info("No updates for sample %s.", lims_id)
@@ -43,15 +48,21 @@ class VougeAdapter(MongoAdapter):
         """Adds/updates a flowcell in the database"""
 
         lims_id = run_news['_id']
-        update_result = self.db.flowcell.update_one({'_id' : lims_id}, {'$set': run_news}, upsert=True)
+        update_result = self.db.flowcell.update_one({'_id': lims_id},
+                                                    {'$set': run_news},
+                                                    upsert=True)
 
         if not update_result.raw_result['updatedExisting']:
-            self.db.flowcell.update_one({'_id' : lims_id}, 
-                {'$set': {'added': dt.today()}})
+            self.db.flowcell.update_one({'_id': lims_id},
+                                        {'$set': {
+                                            'added': dt.today()
+                                        }})
             LOG.info("Added flowcell %s.", lims_id)
         elif update_result.modified_count:
-            self.db.flowcell.update_one({'_id' : lims_id}, 
-                {'$set': {'updated': dt.today()}})
+            self.db.flowcell.update_one({'_id': lims_id},
+                                        {'$set': {
+                                            'updated': dt.today()
+                                        }})
             LOG.info("Updated flowcell %s.", lims_id)
         else:
             LOG.info("No updates for flowcell %s.", lims_id)
@@ -60,26 +71,32 @@ class VougeAdapter(MongoAdapter):
         """Adds/updates a application_tag in the database"""
 
         tag = application_tag_news['_id']
-        update_result = self.db.application_tag.update_one({'_id' : tag}, 
-                            {'$set': application_tag_news}, upsert=True)
+        update_result = self.db.application_tag.update_one(
+            {'_id': tag}, {'$set': application_tag_news}, upsert=True)
 
         if not update_result.raw_result['updatedExisting']:
-            self.db.application_tag.update_one({'_id' : tag}, {'$set': {'added': dt.today()}})
+            self.db.application_tag.update_one({'_id': tag},
+                                               {'$set': {
+                                                   'added': dt.today()
+                                               }})
             LOG.info("Added application_tag %s.", tag)
         elif update_result.modified_count:
-            self.db.application_tag.update_one({'_id' : tag}, {'$set': {'updated': dt.today()}})
+            self.db.application_tag.update_one(
+                {'_id': tag}, {'$set': {
+                    'updated': dt.today()
+                }})
             LOG.info("Updated application_tag %s.", tag)
         else:
             LOG.info("No updates for application_tag %s.", tag)
 
     def sample(self, lims_id):
-        return self.sample_collection.find_one({'_id':lims_id})
+        return self.sample_collection.find_one({'_id': lims_id})
 
     def flowcell(self, run_id):
-        return self.flowcell_collection.find_one({'_id':run_id})
+        return self.flowcell_collection.find_one({'_id': run_id})
 
     def app_tag(self, tag):
-        return self.app_tag_collection.find_one({'_id':tag})
+        return self.app_tag_collection.find_one({'_id': tag})
 
     def delete_sample(self):
         return None
@@ -92,12 +109,26 @@ class VougeAdapter(MongoAdapter):
         update_result = self.db.sample_analysis.find_one({'_id': lims_id})
 
         if update_result is None:
-            self.db.sample_analysis.update_one({'_id' : lims_id}, 
-                    {'$set': {**analysis_result, **{'added': dt.today()}}}, upsert=True)
+            self.db.sample_analysis.update_one(
+                {'_id': lims_id},
+                {'$set': {
+                    **analysis_result,
+                    **{
+                        'added': dt.today()
+                    }
+                }},
+                upsert=True)
             LOG.info("Added analysis sample %s.", lims_id)
         else:
-            self.db.sample_analysis.update_one({'_id' : lims_id}, 
-                    {'$set': {**analysis_result, **{'updated': dt.today()}}}, upsert=True)
+            self.db.sample_analysis.update_one(
+                {'_id': lims_id},
+                {'$set': {
+                    **analysis_result,
+                    **{
+                        'updated': dt.today()
+                    }
+                }},
+                upsert=True)
             LOG.info("Updated analysis for sample %s.", lims_id)
 
     def add_or_update_analysis_case(self, analysis_result: dict):
@@ -109,36 +140,51 @@ class VougeAdapter(MongoAdapter):
         update_result = self.db.case_analysis.find_one({'_id': case_id})
 
         if update_result is None:
-            self.db.case_analysis.update_one({'_id' : case_id}, 
-                    {'$set': {**analysis_result, **{'added': dt.today()}}}, upsert=True)
+            self.db.case_analysis.update_one(
+                {'_id': case_id},
+                {'$set': {
+                    **analysis_result,
+                    **{
+                        'added': dt.today()
+                    }
+                }},
+                upsert=True)
             LOG.info("Added analysis sample %s.", case_id)
         else:
-            self.db.case_analysis.update_one({'_id' : case_id}, 
-                    {'$set': {**analysis_result, **{'updated': dt.today()}}}, upsert=True)
+            self.db.case_analysis.update_one(
+                {'_id': case_id},
+                {'$set': {
+                    **analysis_result,
+                    **{
+                        'updated': dt.today()
+                    }
+                }},
+                upsert=True)
             LOG.info("Updated analysis for sample %s.", case_id)
 
     def sample_analysis(self, analysis_id: str):
         """Functionality to get analyses results"""
-        return self.sample_analysis_collection.find_one({'_id':analysis_id})
+        return self.sample_analysis_collection.find_one({'_id': analysis_id})
 
     def case_analysis(self, analysis_id: str):
         """Functionality to get analyses results"""
-        return self.case_analysis_collection.find_one({'_id':analysis_id})
-        
-    def find_samples(self, query:dict)-> list:
+        return self.case_analysis_collection.find_one({'_id': analysis_id})
+
+    def find_samples(self, query: dict) -> list:
         """Function to find samples in samples collection based on query"""
         samples = self.sample_collection.find(query)
         return list(samples)
 
-    def samples_aggregate(self, pipe : list):
+    def samples_aggregate(self, pipe: list):
         """Function to make a aggregation on the sample colleciton"""
         return self.sample_collection.aggregate(pipe)
 
-    def flowcells_aggregate(self, pipe : list):
+    def flowcells_aggregate(self, pipe: list):
         """Function to make a aggregation on the flowcell colleciton"""
         return self.flowcell_collection.aggregate(pipe)
 
     def get_category(self, app_tag):
         """Function get category based on application tag from the application tag collection"""
-        tag = self.app_tag_collection.find_one({'_id' : app_tag} , { "category": 1 })
+        tag = self.app_tag_collection.find_one({'_id': app_tag},
+                                               {"category": 1})
         return tag.get('category') if tag else None

--- a/vogue/build/analysis.py
+++ b/vogue/build/analysis.py
@@ -102,8 +102,8 @@ def build_mongo_sample(analysis_dict: dict, sample_analysis: dict):
     return analysis
 
 
-def update_mongo_sample(mongo_sample: dict, analysis_dict: dict,
-                        new_analysis: dict):
+def update_mongo_doc_sample(mongo_doc: dict, analysis_dict: dict,
+                            new_analysis: dict):
     '''
     Updates an existing mongo sample dictionary with new analysis dictionary
     Rational on updating an analysis document 
@@ -119,66 +119,145 @@ def update_mongo_sample(mongo_sample: dict, analysis_dict: dict,
     analysis_workflow = analysis_dict['workflow']
     workflow_version = analysis_dict['workflow_version']
 
-    if analysis_case in mongo_sample[
-            'case_names'] and analysis_workflow in mongo_sample['cases'][
+    if analysis_case in mongo_doc[
+            'case_names'] and analysis_workflow in mongo_doc['cases'][
                 analysis_case]['workflows']:
         # 1.a. case exists and workflow exists
-        mongo_sample['cases'][analysis_case][analysis_workflow].extend(
+        mongo_doc['cases'][analysis_case][analysis_workflow].extend(
             new_analysis['cases'][analysis_case][analysis_workflow])
-    elif analysis_case in mongo_sample[
-            'case_names'] and analysis_workflow not in mongo_sample['cases'][
+    elif analysis_case in mongo_doc[
+            'case_names'] and analysis_workflow not in mongo_doc['cases'][
                 analysis_case]['workflows']:
         # 1.b case exists but workflow doesn't
-        mongo_sample['cases'][analysis_case]['workflows'].append(
+        mongo_doc['cases'][analysis_case]['workflows'].append(
             analysis_workflow)
-        mongo_sample['cases'][analysis_case][analysis_workflow] = new_analysis[
+        mongo_doc['cases'][analysis_case][analysis_workflow] = new_analysis[
             'cases'][analysis_case][analysis_workflow]
     else:
         # 2. case doesn't exists, and naturally there won't be any workflows
-        mongo_sample['cases'][analysis_case] = recursive_default_dict()
-        mongo_sample['cases'][analysis_case]['workflows'] = new_analysis[
-            'cases'][analysis_case]['workflows']
-        mongo_sample['cases'][analysis_case][analysis_workflow] = new_analysis[
+        mongo_doc['cases'][analysis_case] = recursive_default_dict()
+        mongo_doc['cases'][analysis_case]['workflows'] = new_analysis['cases'][
+            analysis_case]['workflows']
+        mongo_doc['cases'][analysis_case][analysis_workflow] = new_analysis[
             'cases'][analysis_case][analysis_workflow]
-        mongo_sample['case_names'].append(analysis_case)
-        mongo_sample = convert_defaultdict_to_regular_dict(mongo_sample)
+        mongo_doc['case_names'].append(analysis_case)
+        mongo_doc = convert_defaultdict_to_regular_dict(mongo_doc)
 
-    return mongo_sample
+    return mongo_doc
 
+
+def build_single_case(analysis_dict: dict):
+    '''
+    Prepare a case analysis dictionary
+    '''
+    case_analysis = recursive_default_dict()
+    case_analysis['multiqc'] = copy.deepcopy(analysis_dict['multiqc'])
+    case_analysis = convert_defaultdict_to_regular_dict(case_analysis)
+
+    return case_analysis
+
+
+def build_mongo_case(analysis_dict: dict, case_analysis: dict):
+    '''
+    Build a mongo case docuemtn dictionary
+    '''
+    analysis_case = analysis_dict['case']
+    analysis_workflow = analysis_dict['workflow']
+    workflow_version = analysis_dict['workflow_version']
+    analysis_samples = list(analysis_dict['sample'])
+
+    analysis = recursive_default_dict()
+
+    analysis[analysis_workflow] = list()
+    analysis['workflows'] = list()
+    analysis['samples'] = list()
+
+    workflow_data = {
+        **case_analysis,
+        **{
+            'workflow_version': workflow_version,
+            'added': dt.today()
+        }
+    }
+    analysis[analysis_workflow].append(workflow_data)
+    analysis['workflows'].append(analysis_workflow)
+    analysis['samples'].extend(analysis_samples)
+
+    analysis = convert_defaultdict_to_regular_dict(analysis)
+
+    return analysis
+
+def update_mongo_doc_case(mongo_doc: dict, analysis_dict: dict,
+         new_analysis: dict):
+    '''
+    '''
+
+    analysis_samples = analysis_dict['sample']
+    analysis_case = analysis_dict['case']
+    analysis_workflow = analysis_dict['workflow']
+    workflow_version = analysis_dict['workflow_version']
+
+    if analysis_workflow in mongo_doc['workflows']:
+        # 1.a. case exists and workflow exists
+        mongo_doc[analysis_workflow].extend(new_analysis[analysis_workflow])
+    else:
+        # 1.b case exists but workflow doesn't
+        mongo_doc['workflows'].append(analysis_workflow)
+        mongo_doc[analysis_workflow] = new_analysis[analysis_workflow]
+
+    for sample in analysis_samples:
+        if sample not in mongo_doc['samples']:
+            LOG.info("A new sample %s is added to the case %s",sample, analysis_case)
+            mongo_doc['samples'].append(sample)
+
+    return mongo_doc
 
 def build_analysis(analysis_dict: dict, analysis_type: str,
-                   valid_analysis: list, sample_id: str,
-                   current_analysis: dict):
+                   valid_analysis: list, current_analysis: dict,
+                   build_case: bool):
     '''
-    Builds analysis dictionary based on input analysis_dict and prepares a mongo_sample.
+    Builds analysis dictionary based on input analysis_dict and prepares a mongo_doc.
     '''
 
-    sample_analysis = build_single_sample(analysis_dict=analysis_dict,
-                                          analysis_type=analysis_type,
-                                          valid_analysis=valid_analysis)
+    if build_case:
+        case_analysis = build_single_case(analysis_dict=analysis_dict)
+        analysis = build_mongo_case(analysis_dict=analysis_dict,
+                                    case_analysis=case_analysis)
+    else:
+        sample_analysis = build_single_sample(analysis_dict=analysis_dict,
+                                              analysis_type=analysis_type,
+                                              valid_analysis=valid_analysis)
+        analysis = build_mongo_sample(analysis_dict=analysis_dict,
+                                      sample_analysis=sample_analysis)
 
-    analysis = build_mongo_sample(analysis_dict=analysis_dict,
-                                  sample_analysis=sample_analysis)
-
+    sample_id = analysis_dict['sample']
     analysis_case = analysis_dict['case']
     analysis_workflow = analysis_dict['workflow']
     workflow_version = analysis_dict['workflow_version']
 
     if current_analysis is None:
         # if there is no current analysis, return the built analysis
-        mongo_sample = copy.deepcopy(analysis)
-        mongo_sample['_id'] = sample_id
+        mongo_doc = copy.deepcopy(analysis)
+        if build_case:
+            mongo_doc['_id'] = analysis_case
+        else:
+            mongo_doc['_id'] = sample_id
 
     else:
         # if there is a current analysis, pop added and updated keys
         # and continue building the rest of the mongo sample
-        mongo_sample = copy.deepcopy(current_analysis)
-        mongo_sample.pop('added')
-        if 'updated' in mongo_sample.keys():
-            mongo_sample.pop('updated')
+        mongo_doc = copy.deepcopy(current_analysis)
+        mongo_doc.pop('added')
+        if 'updated' in mongo_doc.keys():
+            mongo_doc.pop('updated')
 
-        mongo_sample = update_mongo_sample(mongo_sample=mongo_sample,
-                                           analysis_dict=analysis_dict,
-                                           new_analysis=analysis)
+        if build_case:
+            mongo_doc = update_mongo_doc_case(mongo_doc=mongo_doc,
+                                              analysis_dict=analysis_dict,
+                                              new_analysis=analysis)
+        else:
+            mongo_doc = update_mongo_doc_sample(mongo_doc=mongo_doc,
+                                                analysis_dict=analysis_dict,
+                                                new_analysis=analysis)
 
-    return mongo_sample
+    return mongo_doc

--- a/vogue/build/analysis.py
+++ b/vogue/build/analysis.py
@@ -187,8 +187,9 @@ def build_mongo_case(analysis_dict: dict, case_analysis: dict):
 
     return analysis
 
+
 def update_mongo_doc_case(mongo_doc: dict, analysis_dict: dict,
-         new_analysis: dict):
+                          new_analysis: dict):
     '''
     '''
 
@@ -207,10 +208,12 @@ def update_mongo_doc_case(mongo_doc: dict, analysis_dict: dict,
 
     for sample in analysis_samples:
         if sample not in mongo_doc['samples']:
-            LOG.info("A new sample %s is added to the case %s",sample, analysis_case)
+            LOG.info("A new sample %s is added to the case %s", sample,
+                     analysis_case)
             mongo_doc['samples'].append(sample)
 
     return mongo_doc
+
 
 def build_analysis(analysis_dict: dict, analysis_type: str,
                    valid_analysis: list, current_analysis: dict,

--- a/vogue/commands/load/analysis.py
+++ b/vogue/commands/load/analysis.py
@@ -1,9 +1,12 @@
 import logging
+import copy
 import click
 
 from flask.cli import with_appcontext, current_app
+from flask import abort as flaskabort
 
 from vogue.tools.cli_utils import json_read
+from vogue.tools.cli_utils import dict_replace_dot
 from vogue.tools.cli_utils import yaml_read
 from vogue.tools.cli_utils import check_file
 from vogue.tools.cli_utils import concat_dict_keys
@@ -18,7 +21,11 @@ LOG = logging.getLogger(__name__)
 
 
 @click.command("analysis", short_help="Read files from analysis workflows")
-@click.option('-s', '--sample-id', required=True, help='Input sample id')
+@click.option('-s',
+              '--sample-id',
+              required=True,
+              multiple=True,
+              help='Input sample id.')
 @click.option('-a',
               '--analysis-config',
               type=click.Path(),
@@ -32,13 +39,11 @@ LOG = logging.getLogger(__name__)
     multiple=True,
     default=['all'],
     help='Type of analysis results to load.')
-@click.option(
-    '-c',
-    '--analysis-case',
-    required=True,
-    help=
-    'The case that this sample belongs to. It can be specified multiple times.'
-)
+@click.option('-c',
+              '--analysis-case',
+              required=True,
+              help='''The case that this sample belongs.
+        It can be specified multiple times.''')
 @click.option('-w',
               '--analysis-workflow',
               required=True,
@@ -46,6 +51,10 @@ LOG = logging.getLogger(__name__)
 @click.option('--workflow-version',
               required=True,
               help='Analysis workflow used.')
+@click.option(
+    '--multiqc',
+    is_flag=True,
+    help='Specify this flag if input json is unprocess multiqc output.')
 @click.option('--dry', is_flag=True, help='Load from sample or not. (dry-run)')
 @doc(f"""
     Read and load analysis results. These are either QC or analysis output files.
@@ -55,9 +64,23 @@ LOG = logging.getLogger(__name__)
         """)
 @with_appcontext
 def analysis(sample_id, dry, analysis_config, analysis_type, analysis_case,
-             analysis_workflow, workflow_version):
+             analysis_workflow, workflow_version, multiqc):
+
+    # multiqc does not work with multiple input analysis configs
+    if multiqc and len(analysis_config) > 1:
+        LOG.error("multiqc flag cannot be used with multiple input files")
+        raise click.Abort()
+
+    if not multiqc and len(sample_id) > 1:
+        LOG.error("for standard input, only use single sample ids.")
+        raise click.Abort()
+
+    if not multiqc:
+        sample_id = copy.deepcopy(sample_id[0])
 
     analysis_dict = dict()
+
+    #if multiqc flag is enabled, build dictionary without merging.
     # Loop over list of input config files for single sample and merge them into
     # one single dictionary
     for input_config in analysis_config:
@@ -66,7 +89,7 @@ def analysis(sample_id, dry, analysis_config, analysis_type, analysis_case,
         try:
             check_file(input_config)
         except FileNotFoundError:
-            click.Abort()
+            raise click.Abort()
 
         LOG.info("Trying JSON format")
         tmp_analysis_dict = json_read(input_config)
@@ -77,39 +100,53 @@ def analysis(sample_id, dry, analysis_config, analysis_type, analysis_case,
             if not isinstance(tmp_analysis_dict, dict):
                 LOG.error(
                     "Cannot read input analysis config file. Type unknown.")
-                click.Abort()
+                raise click.Abort()
 
         analysis_dict = {**analysis_dict, **tmp_analysis_dict}
+    
+    analysis_dict = dict_replace_dot(analysis_dict)
 
-    LOG.info("Validating parsed config file(s).")
-    valid_analysis = validate_conf(analysis_dict)
-    if valid_analysis is None:
-        LOG.error("Invalid or badly formatted file(s).")
-        click.Abort()
+    if not multiqc:
+        LOG.info("Validating parsed config file(s).")
+        valid_analysis = validate_conf(analysis_dict)
+        if valid_analysis is None:
+            LOG.error("Invalid or badly formatted file(s).")
+            raise click.Abort()
+    else:
+        old_keys = list(analysis_dict.keys())
+        analysis_dict['multiqc'] = copy.deepcopy(analysis_dict)
+        valid_analysis=dict()
+        for key in old_keys:
+            analysis_dict.pop(key)
 
     analysis_dict['case'] = analysis_case
     analysis_dict['workflow'] = analysis_workflow
     analysis_dict['workflow_version'] = workflow_version
+    analysis_dict['sample'] = sample_id
 
     # Get current sample if any
-    current_analysis = current_app.adapter.analysis(sample_id)
+    if not multiqc:
+        current_analysis = current_app.adapter.sample_analysis(sample_id)
+    else:
+        current_analysis = current_app.adapter.case_analysis(analysis_case)
 
     ready_analysis = build_analysis(analysis_dict=analysis_dict,
                                     analysis_type=analysis_type,
                                     valid_analysis=valid_analysis,
-                                    sample_id=sample_id,
-                                    current_analysis=current_analysis)
+                                    current_analysis=current_analysis,
+                                    build_case=multiqc)
 
-    if ready_analysis:
-        LOG.info(
-            'Values for %s  loaded for sample %s', list(ready_analysis.keys()), sample_id
-        )
+    if ready_analysis and not multiqc:
+        LOG.info('Values for %s  loaded for sample %s',
+                 list(ready_analysis.keys()), sample_id)
+    elif not ready_analysis and not multiqc:
+        LOG.warning('No enteries were found for the given analysis type: %s',
+                    analysis_type)
     else:
-        LOG.warning(
-            'No enteries were found for the given analysis type: %s', analysis_type
-        )
+        LOG.info('Case %s will be added/updated', analysis_case)
 
     load_analysis(adapter=current_app.adapter,
                   lims_id=sample_id,
+                  is_case=multiqc,
                   dry_run=dry,
                   analysis=ready_analysis)

--- a/vogue/commands/load/analysis.py
+++ b/vogue/commands/load/analysis.py
@@ -103,7 +103,7 @@ def analysis(sample_id, dry, analysis_config, analysis_type, analysis_case,
                 raise click.Abort()
 
         analysis_dict = {**analysis_dict, **tmp_analysis_dict}
-    
+
     analysis_dict = dict_replace_dot(analysis_dict)
 
     if not multiqc:
@@ -115,7 +115,7 @@ def analysis(sample_id, dry, analysis_config, analysis_type, analysis_case,
     else:
         old_keys = list(analysis_dict.keys())
         analysis_dict['multiqc'] = copy.deepcopy(analysis_dict)
-        valid_analysis=dict()
+        valid_analysis = dict()
         for key in old_keys:
             analysis_dict.pop(key)
 

--- a/vogue/load/analysis.py
+++ b/vogue/load/analysis.py
@@ -3,7 +3,7 @@ import logging
 LOG = logging.getLogger(__name__)
 
 
-def load_analysis(adapter, lims_id, analysis, dry_run=False):
+def load_analysis(adapter, lims_id, analysis, is_case, dry_run=False):
     """Load information from a cancer analysis"""
 
     if dry_run:
@@ -17,4 +17,7 @@ def load_analysis(adapter, lims_id, analysis, dry_run=False):
                  lims_id, analysis)
         return
 
-    adapter.add_or_update_analysis(analysis)
+    if is_case:
+        adapter.add_or_update_analysis_case(analysis)
+    else:
+        adapter.add_or_update_analysis_sample(analysis)

--- a/vogue/tools/cli_utils.py
+++ b/vogue/tools/cli_utils.py
@@ -8,11 +8,13 @@ import copy
 LOG_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
 LOG = logging.getLogger(__name__)
 
+
 def convert_dot(string):
     '''
     replaces dot with underscore
     '''
-    return string.replace(".","_")
+    return string.replace(".", "_")
+
 
 def add_doc(docstring):
     """
@@ -25,19 +27,22 @@ def add_doc(docstring):
 
     return document
 
+
 def dict_replace_dot(obj):
     '''
     recursively replace all dots in json.load keys.
     '''
-    if isinstance(obj,dict):
+    if isinstance(obj, dict):
         for key in obj.keys():
             obj[convert_dot(key)] = obj.pop(key)
-            if isinstance(obj[convert_dot(key)],dict) or isinstance(obj[convert_dot(key)],list):
+            if isinstance(obj[convert_dot(key)], dict) or isinstance(
+                    obj[convert_dot(key)], list):
                 obj[convert_dot(key)] = dict_replace_dot(obj[convert_dot(key)])
-    elif isinstance(obj,list):
+    elif isinstance(obj, list):
         for item in obj:
             item = dict_replace_dot(item)
     return obj
+
 
 def json_read(fname):
     """
@@ -50,7 +55,8 @@ def json_read(fname):
             return analysis_conf
     except:
         LOG.warning('Input config is not JSON')
-        return False 
+        return False
+
 
 def yaml_read(fname):
     """
@@ -65,6 +71,7 @@ def yaml_read(fname):
         LOG.warning('Input config is not YAML')
         return False
 
+
 def check_file(fname):
     """
     Check file exists and readable.
@@ -75,6 +82,7 @@ def check_file(fname):
     if not path.exists() or not path.is_file():
         LOG.error("File not found or input is not a file.")
         raise FileNotFoundError
+
 
 def concat_dict_keys(my_dict: dict, key_name="", out_key_list=list()):
     '''


### PR DESCRIPTION
This PR addresses addition/update of a raw multiqc json file into the case_analysis collection. This will make it easier to validate and extract information for each sample and create a summary view from it. So here we go. This PR does the following:

1.  updates `vogue load analysis` with a new option to specify if it is a case level input:
```
  --is-case                       Specify this flag if input json is case
                                  level.
  --case-analysis-type [multiqc]  Specify the type for the case analysis. i.e.
                                  if it is multiqc output, then choose multiqc
```

2. Creates a new collection called `case_analysis` with the following **suggest** structure:
![image](https://user-images.githubusercontent.com/1086877/57455613-cf824900-726b-11e9-9d6a-2d873b278030.png)

This PR **DOES NOT**:
- validate if samples are indeed in the multiqc report.
- validate any of the values or keys within the report.
- validate nor checks if the structure within multiqc report is correct or proper.

To test this PR:

1. `git clone analysis_load_multiqc`
2. set the following environment variables:
```
export FLASK_DEBUG=0
export MONGO_URI=mongodb://localhost:${port_for_mongo_db}
export MONGO_DBNAME=${dbname_within_mongod}
export VOGUE_SECRET_KEY=${your_secret_key}
```
3. 
```
vogue load analysis \
    --sample-id test_sample_1 \
    --sample-id test_sample_2 \
    --sample-id test_sample_3 \
    --analysis-config multiqc_data.json \
    --analysis-case cutealligator \
    --analysis-workflow balsamico \
    --workflow-version 3.14.15.2.79 \
    --is-case \
    --case-analysis-type multiqc
```