### PR TITLE
fix(analysis): updates case_analysis_type properly passed to build utils

### DIFF
--- a/vogue/build/case_analysis.py
+++ b/vogue/build/case_analysis.py
@@ -146,12 +146,12 @@ def update_mongo_doc_sample(mongo_doc: dict, analysis_dict: dict,
     return mongo_doc
 
 
-def build_single_case(analysis_dict: dict):
+def build_single_case(analysis_dict: dict, case_analysis_type: str):
     '''
     Prepare a case analysis dictionary
     '''
     case_analysis = recursive_default_dict()
-    case_analysis['multiqc'] = copy.deepcopy(analysis_dict['multiqc'])
+    case_analysis[case_analysis_type] = copy.deepcopy(analysis_dict[case_analysis_type])
     case_analysis = convert_defaultdict_to_regular_dict(case_analysis)
 
     return case_analysis
@@ -217,13 +217,13 @@ def update_mongo_doc_case(mongo_doc: dict, analysis_dict: dict,
 
 def build_analysis(analysis_dict: dict, analysis_type: str,
                    valid_analysis: list, current_analysis: dict,
-                   build_case: bool):
+                   case_analysis_type: str, build_case: bool):
     '''
     Builds analysis dictionary based on input analysis_dict and prepares a mongo_doc.
     '''
 
     if build_case:
-        case_analysis = build_single_case(analysis_dict=analysis_dict)
+        case_analysis = build_single_case(analysis_dict=analysis_dict, case_analysis_type=case_analysis_type)
         analysis = build_mongo_case(analysis_dict=analysis_dict,
                                     case_analysis=case_analysis)
     else:

--- a/vogue/commands/load/case_analysis.py
+++ b/vogue/commands/load/case_analysis.py
@@ -141,6 +141,7 @@ def analysis(sample_id, dry, analysis_config, analysis_type, analysis_case,
                                     analysis_type=analysis_type,
                                     valid_analysis=valid_analysis,
                                     current_analysis=current_analysis,
+                                    case_analysis_type=case_analysis_type,
                                     build_case=is_case)
 
     if ready_analysis and not is_case:


### PR DESCRIPTION
This PR adds the following:

1. update collections in case_analysis to take the value from input options
![image](https://user-images.githubusercontent.com/1086877/60791894-e7d7ec80-a164-11e9-9bcf-24fd19101cb5.png)

This PR DOES NOT:

- validate if samples are indeed in the input json file
- validate any of the values or keys within the input json file
- validate nor checks if the structure within input json file is correct or proper. As long as it is a valid json it is all good! relies on source to provide a proper report.

To test this PR:
1. `git checkout custom_case_load`
2. set the following environment variables:
```
export FLASK_DEBUG=0
export MONGO_URI=mongodb://localhost:${port_for_mongo_db}
export MONGO_DBNAME=${dbname_within_mongod}
export VOGUE_SECRET_KEY=${your_secret_key}
```
3. set the value for `case-analysis-type` to `custom`:
```
vogue load analysis \
    --sample-id test_sample_1 \
    --sample-id test_sample_2 \
    --sample-id test_sample_3 \
    --analysis-config multiqc_data.json \
    --analysis-case cutealligator \
    --analysis-workflow balsamico \
    --workflow-version 3.14.15.2.79 \
    --is-case \
    --case-analysis-type custom
```