### PR TITLE
Version fix

### DIFF
--- a/vogue/commands/base.py
+++ b/vogue/commands/base.py
@@ -19,9 +19,9 @@ from vogue.tools.cli_utils import add_doc as doc
 LOG_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
 LOG = logging.getLogger(__name__)
 
-@click.group(cls=FlaskGroup, create_app=create_app)
-@click.version_option(version=__version__)
-def cli():
+@click.version_option(__version__)
+@click.group(cls=FlaskGroup, create_app=create_app, add_default_commands=True, invoke_without_command=False)
+def cli(**_):
     """ Main entry point """
     pass 
 
@@ -40,4 +40,4 @@ def name():
 
 cli.add_command(test)
 cli.add_command(load)
-test.add_command(name)
+cli.add_command(name)

--- a/vogue/commands/base.py
+++ b/vogue/commands/base.py
@@ -19,9 +19,13 @@ from vogue.tools.cli_utils import add_doc as doc
 LOG_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
 LOG = logging.getLogger(__name__)
 
-cli = FlaskGroup(create_app=create_app)
+@click.group(cls=FlaskGroup, create_app=create_app)
+@click.version_option(version=__version__)
+def cli():
+    """ Main entry point """
+    pass 
 
-@click.group()
+@cli.command()
 def test():
     """Test server using CLI"""
     click.echo("test")

--- a/vogue/commands/base.py
+++ b/vogue/commands/base.py
@@ -19,11 +19,17 @@ from vogue.tools.cli_utils import add_doc as doc
 LOG_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
 LOG = logging.getLogger(__name__)
 
+
 @click.version_option(__version__)
-@click.group(cls=FlaskGroup, create_app=create_app, add_default_commands=True, invoke_without_command=False)
+@click.group(cls=FlaskGroup,
+             create_app=create_app,
+             add_default_commands=True,
+             invoke_without_command=False,
+             add_version_option=False)
 def cli(**_):
     """ Main entry point """
-    pass 
+    pass
+
 
 @cli.command()
 def test():
@@ -31,12 +37,14 @@ def test():
     click.echo("test")
     pass
 
+
 @cli.command()
 @with_appcontext
 def name():
     """Returns the app name, for testing purposes, mostly"""
     click.echo(current_app.name)
     return current_app.name
+
 
 cli.add_command(test)
 cli.add_command(load)


### PR DESCRIPTION
This PR fixes the `--version` command issue #147 

- simplifies FlaskGroup addition
- simplifies main entry point

Expected outcome:
```
vogue --version
vogue, version 0.2.0
```

Vogue requires the following to be set if MongoDB is up and running:
```
export FLASK_DEBUG=0
export MONGO_URI=mongodb://localhost:27030
export MONGO_DBNAME=vogue-stage
export VOGUE_SECRET_KEY=some_key
```