### PR TITLE
Vogue config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ This change log will document the notable changes to this project in this file a
 ## [x.x.x]
 
 ### Changed
-- Removing environment vareable dependency and instead adding option for config.
+- Added posibility to run vogue with config as environment vareable
+- Removing environment vareable dependency and instead adding option for config in cli.
 - Squashed the load document functions into one general function
 - setting werkzeug<1.0.0 in requirements.txt
 

--- a/vogue/commands/base.py
+++ b/vogue/commands/base.py
@@ -3,7 +3,6 @@ import logging
 
 import click
 import coloredlogs
-import yaml
 
 
 from flask.cli import FlaskGroup, with_appcontext
@@ -29,23 +28,12 @@ LOG = logging.getLogger(__name__)
              invoke_without_command=False,
              add_version_option=False)
 @click.option("-c", "--config", type=click.File(), help="Path to config file")
-@click.option("-u", "--db-uri", type=str, default='mongodb://localhost:27030', help="Set db uri if no config is provided")
-@click.option("-n", "--db-name", type=str, default='vogue-stage', help="Set db name to connect if no config is provided.")
-@click.option("-d", "--flask-debug", type=click.Choice(["0", "1"]), default="1", help="Debug mode for Flask if no config is provided.")
-@click.option("-s", "--secret-key", type=str, default='hej', help="Secret key for the flask application if no config is provided.")
 @with_appcontext
-def cli(config, db_uri, db_name, flask_debug, secret_key):
+def cli(config):
     """ Main entry point """
     if current_app.test:
         return
-    if config:
-        configure_app(current_app, yaml.safe_load(config))
-    else:
-        configure_app(current_app, {'DB_URI': db_uri,
-                                    'DB_NAME': db_name,
-                                    'DEBUG': flask_debug, 
-                                    'SECRET_KEY': secret_key}
-                        )
+    configure_app(current_app, config)
     pass
 
 

--- a/vogue/server/__init__.py
+++ b/vogue/server/__init__.py
@@ -23,11 +23,12 @@ def create_app(test=False):
     app.test = test
     try:
         app.config.from_envvar('VOGUE_CONFIG')
+        configure_app(app)
     except:
         pass
     return app
 
-def configure_app(app, config):
+def configure_app(app, config=None):
     try:
         app.lims = Lims(BASEURI,USERNAME,PASSWORD)
     except:

--- a/vogue/server/__init__.py
+++ b/vogue/server/__init__.py
@@ -21,6 +21,10 @@ LOG = logging.getLogger(__name__)
 def create_app(test=False):
     app = Flask(__name__)
     app.test = test
+    try:
+        app.config.from_envvar('VOGUE_CONFIG')
+    except:
+        pass
     return app
 
 def configure_app(app, config):
@@ -31,12 +35,7 @@ def configure_app(app, config):
 
     if config:
         app.config = {**app.config, **yaml.safe_load(config)}
-    else:
-        try:
-            app.config.from_envvar('VOGUE_CONFIG')
-        except:
-            pass
-
+        
     client = MongoClient(app.config['DB_URI'])
     db_name = app.config['DB_NAME']
     app.client = client

--- a/vogue/server/__init__.py
+++ b/vogue/server/__init__.py
@@ -16,16 +16,18 @@ logging.basicConfig(level=logging.INFO)
 LOG = logging.getLogger(__name__)
 
 
-
-
 def create_app(test=False):
     app = Flask(__name__)
     app.test = test
+    if test:
+        return app
+
     try:
         app.config.from_envvar('VOGUE_CONFIG')
         configure_app(app)
     except:
         pass
+
     return app
 
 def configure_app(app, config=None):
@@ -36,7 +38,7 @@ def configure_app(app, config=None):
 
     if config:
         app.config = {**app.config, **yaml.safe_load(config)}
-        
+
     client = MongoClient(app.config['DB_URI'])
     db_name = app.config['DB_NAME']
     app.client = client

--- a/vogue/server/__init__.py
+++ b/vogue/server/__init__.py
@@ -4,6 +4,7 @@ import logging
 
 from flask import Flask
 from pymongo import MongoClient
+import yaml
 
 from vogue.adapter.plugin import VougeAdapter
 from vogue.server.views import blueprint
@@ -27,7 +28,15 @@ def configure_app(app, config):
         app.lims = Lims(BASEURI,USERNAME,PASSWORD)
     except:
         app.lims = None
-    app.config = {**app.config, **config}
+
+    if config:
+        app.config = {**app.config, **yaml.safe_load(config)}
+    else:
+        try:
+            app.config.from_envvar('VOGUE_CONFIG')
+        except:
+            pass
+
     client = MongoClient(app.config['DB_URI'])
     db_name = app.config['DB_NAME']
     app.client = client


### PR DESCRIPTION
Added posibility to run vogue with config as environment vareable


**How to prepare for test**:
- [x] ssh to clinical-db
- [x] install on S_vogue of clinical-db:
`bash servers/resources/clinical-db.sclifelab.se/update-vogue-stage.sh [THIS-BRANCH-NAME]`

**How to test**:
- [ ] create a test_config.py and set the env variable VOGUE_CONFIG
```
DB_URI= 'mongodb://localhost:27030'
DB_NAME= 'vogue-stage'
DEBUG= 0
SECRET_KEY= 'hej'
```
- [ ] Update supervisor_conf with the new env var.
environment = VOGUE_CONFIG=/home/hiseq.clinical/test_config.py
- [ ] restart supervisor ctrl for vogue_stage

**Expected test outcome**:
- [ ] go to https://vogue-stage.scilifelab.se/ to see that it is up and running

**Review:**
- [x] code approved by @hassanfa 
- [x] tests executed by @mayabrandi 
- [x] "Merge and deploy" approved by 
Thanks for filling in who performed the code review and the test!


This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

