### PR TITLE
Update genologic to 0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This change log will document the notable changes to this project in this file a
 - Removing environment vareable dependency and instead adding option for config in cli.
 - Squashed the load document functions into one general function
 - setting werkzeug<1.0.0 in requirements.txt
+- Update genologic to 0.4.6
 
 ### Added
 - code owners

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ click
 bumpversion
 pyyaml
 pymongo
-genologics
+genologics>=0.4.6
 yapf
 flask
 coloredlogs


### PR DESCRIPTION
Update genologic to 0.4.6. 

**Review:**
- [x] code approved by
- [x] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!


This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
