### PR TITLE
Fix, duplicate and simplified multiqc load

### DIFF
--- a/vogue/build/bioinfo_analysis.py
+++ b/vogue/build/bioinfo_analysis.py
@@ -175,14 +175,12 @@ def build_mongo_case(analysis_dict: dict, case_analysis: dict,
 
 def update_mongo_doc_case(mongo_doc: dict,
                           analysis_dict: dict,
-                          new_analysis: dict,
-                          processed=False):
+                          new_analysis: dict):
     '''
     Args:
         mongo_doc: an existing analysis retrieved from MongoDB 
         analysis_dict: a dictionary parsed from CLI
         new_analysis: new analysis dictionary to be loaded to MongoDB
-        processed: A Flag to indicate which type of data it is dealing with
 
     Returns:
         mongo_doc: an updated mongo_doc from Args
@@ -267,8 +265,7 @@ def build_analysis(analysis_dict: dict,
 
         mongo_doc = update_mongo_doc_case(mongo_doc=mongo_doc,
                                           analysis_dict=analysis_dict,
-                                          new_analysis=analysis,
-                                          processed=process_case)
+                                          new_analysis=analysis)
 
     return mongo_doc
 

--- a/vogue/build/bioinfo_analysis.py
+++ b/vogue/build/bioinfo_analysis.py
@@ -189,21 +189,12 @@ def update_mongo_doc_case(mongo_doc: dict,
     workflow_version = analysis_dict['workflow_version']
 
     if not processed:
-        if analysis_workflow in mongo_doc[
-                'workflows'] and case_analysis_type in mongo_doc[
-                    'case_analysis_types']:
-            # 1.a. case exists and workflow exists
-            mongo_doc[analysis_workflow][case_analysis_type].extend(
-                new_analysis[analysis_workflow][case_analysis_type])
-        elif analysis_workflow in mongo_doc[
-                'workflows'] and case_analysis_type not in mongo_doc[
-                    'case_analysis_types']:
-            # 1.b. case exists and workflow exists
+        # if workflow doesn't exist. e.g. previous workflow was mip, and now loading from balsamic
+        if analysis_workflow in mongo_doc['workflows'] :
             mongo_doc[analysis_workflow][case_analysis_type] = copy.deepcopy(
                 new_analysis[analysis_workflow][case_analysis_type])
-            mongo_doc['case_analysis_types'].append(case_analysis_type)
+            mongo_doc['case_analysis_types'] = case_analysis_type
         else:
-            # 1.c case exists but workflow doesn't
             mongo_doc['workflows'].append(analysis_workflow)
             mongo_doc[analysis_workflow] = new_analysis[analysis_workflow]
     else:
@@ -213,20 +204,16 @@ def update_mongo_doc_case(mongo_doc: dict,
                 **new_analysis[analysis_workflow]
             }
         else:
-            mongo_doc[analysis_workflow][case_analysis_type] = new_analysis[
-                analysis_workflow][case_analysis_type]
+            new_workflow_analysis = dict()
+            new_workflow_analysis[case_analysis_type] = new_analysis[analysis_workflow][case_analysis_type]
+            mongo_doc[analysis_workflow] = copy.deepcopy(new_workflow_analysis) 
+            mongo_doc['workflows'].append(analysis_workflow)
 
         if case_analysis_type not in mongo_doc['case_analysis_types']:
+            LOG.info("A new analysis type %s is added to the case %s", case_analysis_type,
+                     analysis_case)
             mongo_doc['case_analysis_types'].append(case_analysis_type)
 
-
-#        if case_analysis_type in mongo_doc['case_analysis_types']:
-#             # 1.a. case exists and workflow exists
-#             mongo_doc[case_analysis_type].extend(new_analysis[case_analysis_type])
-#        else:
-#            # 1.b. case exists and workflow exists
-#            mongo_doc[case_analysis_type] = copy.deepcopy(new_analysis[case_analysis_type])
-#            mongo_doc['case_analysis_types'].append(case_analysis_type)
 
     for sample in analysis_samples:
         if sample not in mongo_doc['samples']:

--- a/vogue/build/bioinfo_analysis.py
+++ b/vogue/build/bioinfo_analysis.py
@@ -193,36 +193,26 @@ def update_mongo_doc_case(mongo_doc: dict,
 
     analysis_samples = analysis_dict['sample']
     analysis_case = analysis_dict['case']
-    case_analysis_type = analysis_dict['case_analysis_type']
-    analysis_workflow = analysis_dict['workflow']
+    analysis_type = analysis_dict['case_analysis_type']
+    analysis_workflow_type = analysis_dict['workflow']
     workflow_version = analysis_dict['workflow_version']
 
-    if not processed:
-        # if workflow doesn't exist. e.g. previous workflow was mip, and now loading from balsamic
-        if analysis_workflow in mongo_doc['workflows'] :
-            mongo_doc[analysis_workflow][case_analysis_type] = copy.deepcopy(
-                new_analysis[analysis_workflow][case_analysis_type])
-            mongo_doc['case_analysis_types'] = case_analysis_type
-        else:
-            mongo_doc['workflows'].append(analysis_workflow)
-            mongo_doc[analysis_workflow] = new_analysis[analysis_workflow]
+    
+    if analysis_workflow_type not in mongo_doc:
+        mongo_doc[analysis_workflow_type] = {} 
+
+    if analysis_type not in mongo_doc[analysis_workflow_type]:
+        mongo_doc[analysis_workflow_type][analysis_type] = new_analysis[analysis_workflow_type][analysis_type]
     else:
-        if analysis_workflow in mongo_doc['workflows']:
-            mongo_doc[analysis_workflow] = {
-                **mongo_doc[analysis_workflow],
-                **new_analysis[analysis_workflow]
-            }
-        else:
-            new_workflow_analysis = dict()
-            new_workflow_analysis[case_analysis_type] = new_analysis[analysis_workflow][case_analysis_type]
-            mongo_doc[analysis_workflow] = copy.deepcopy(new_workflow_analysis) 
-            mongo_doc['workflows'].append(analysis_workflow)
+        mongo_doc[analysis_workflow_type] = {**new_analysis[analysis_workflow_type],
+                                             **mongo_doc[analysis_workflow_type]}
+            
+    if analysis_workflow_type not in mongo_doc['workflows']:
+        mongo_doc['workflows'].append(analysis_workflow_type)
 
-        if case_analysis_type not in mongo_doc['case_analysis_types']:
-            LOG.info("A new analysis type %s is added to the case %s", case_analysis_type,
-                     analysis_case)
-            mongo_doc['case_analysis_types'].append(case_analysis_type)
-
+    if analysis_type not in mongo_doc['case_analysis_types']:
+        LOG.info("A new analysis type %s is added to the case %s", analysis_type, analysis_case)
+        mongo_doc['case_analysis_types'].append(analysis_type)
 
     for sample in analysis_samples:
         if sample not in mongo_doc['samples']:

--- a/vogue/build/bioinfo_analysis.py
+++ b/vogue/build/bioinfo_analysis.py
@@ -178,6 +178,15 @@ def update_mongo_doc_case(mongo_doc: dict,
                           new_analysis: dict,
                           processed=False):
     '''
+    Args:
+        mongo_doc: an existing analysis retrieved from MongoDB 
+        analysis_dict: a dictionary parsed from CLI
+        new_analysis: new analysis dictionary to be loaded to MongoDB
+        processed: A Flag to indicate which type of data it is dealing with
+
+    Returns:
+        mongo_doc: an updated mongo_doc from Args
+
     Add or update mongo document for case data
     Adds or updates within processed or raw bioinfo collection
     '''

--- a/vogue/commands/load/bioinfo/bioinfo_raw.py
+++ b/vogue/commands/load/bioinfo/bioinfo_raw.py
@@ -101,6 +101,12 @@ def bioinfo_raw(dry, analysis_result, analysis_type, analysis_case,
 
     analysis_dict = dict_replace_dot(analysis_dict)
 
+    if case_analysis_type == "multiqc":
+        LOG.info("--case-analysis-type set to multiqc, taking only report_saved_raw_data key")
+        report_saved_raw_data = analysis_dict["report_saved_raw_data"]
+        analysis_dict.clear()
+        analysis_dict["report_saved_raw_data"] = copy.deepcopy(report_saved_raw_data)
+
     # Get current sample if any
     old_keys = list(analysis_dict.keys())
     analysis_dict[case_analysis_type] = copy.deepcopy(analysis_dict)


### PR DESCRIPTION
This PR fixes the following:

1. Always uploads fresh data into `bioinfo_raw`
2. Only take multiqc's relevant section

It is an attempt to quickly address https://github.com/Clinical-Genomics/cg/pull/650

Does any of the following questions apply to this PR:
- [ ] ~Is the view is self explanatory?~ No related to this PR
- [ ] Is the data is correctly displayed in the plot/plots? 
- [ ] Is the data correctly loaded into the trending database?

**How to prepare for test**:
- [ ] ssh to clinical-db
- [ ] install on stage of clinical-db:
`bash servers/resources/clinical-db.sclifelab.se/update-cgweb-stage.sh [THIS-BRANCH-NAME]`

**How to test**:
- [ ] login on https://clinical-stage.scilifelab.se/
- [ ] click on ...

**Expected test outcome**:
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @mayabrandi 
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!


This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
