### PR TITLE
Covid

### DIFF
--- a/vogue/build/sample.py
+++ b/vogue/build/sample.py
@@ -35,6 +35,7 @@ def build_sample(sample: Sample, lims: Lims, adapter) -> dict:
     mongo_sample['priority'] = sample.udf.get('priority')
     mongo_sample['initial_qc'] = sample.udf.get('Passed Initial QC')
     mongo_sample['library_qc'] = sample.udf.get('Passed Library QC')
+    mongo_sample['prep_method'] = sample.udf.get('Prep Method')
     mongo_sample['sequencing_qc'] = sample.udf.get('Passed Sequencing QC')
     mongo_sample['application_tag'] = application_tag
     mongo_sample['category'] = category

--- a/vogue/server/__init__.py
+++ b/vogue/server/__init__.py
@@ -7,6 +7,7 @@ import yaml
 
 from vogue.adapter.plugin import VougeAdapter
 from vogue.server.views import blueprint
+from vogue.server.endpoints.covid import covid_blueprint
 
 from genologics.lims import Lims
 from genologics.config import BASEURI, USERNAME, PASSWORD
@@ -45,6 +46,7 @@ def configure_app(app, config=None):
     app.db = client[db_name]
     app.adapter = VougeAdapter(client, db_name=db_name)
     app.register_blueprint(blueprint)
+    app.register_blueprint(covid_blueprint)
 
     if app.config['DEBUG'] == 1:
         from flask_debugtoolbar import DebugToolbarExtension

--- a/vogue/server/endpoints/covid.py
+++ b/vogue/server/endpoints/covid.py
@@ -1,21 +1,22 @@
 #!/usr/bin/env python
 
-from flask import url_for, redirect, render_template, request, Blueprint, current_app
+from flask import render_template, request, Blueprint, current_app
 
-from vogue.constants.constants import *
-from vogue.server.utils import *
+from vogue.constants.constants import MICROSALT, YEARS
+from vogue.server.utils import microsalt_get_qc_time
 from vogue.server.utils.covid import get_qc
 from vogue import __version__
 
 app = current_app
 covid_blueprint = Blueprint('covid', __name__)
 
-
-HEADER= 'Microsalt Covid'
+HEADER = 'Microsalt Covid'
 
 
 @covid_blueprint.route('/Bioinfo/Covid/qc_time/<year>', methods=['GET', 'POST'])
 def microsalt_qc_time(year):
+    """Box plot with qc data per month"""
+
     metric_path = request.form.get('qc_metric',
                                    'picard_markduplicate.insert_size')
     results = microsalt_get_qc_time(app.adapter, year=year, metric_path=metric_path, category='cov')
@@ -35,9 +36,10 @@ def microsalt_qc_time(year):
                            years=YEARS)
 
 
-
 @covid_blueprint.route('/Bioinfo/Covid/qc_time_scatter/<year>', methods=['GET', 'POST'])
 def qc_scatter(year):
+    """Scatter plot with qc data over time, grouped by prep method"""
+
     metric_path = request.form.get('qc_metric',
                                    'picard_markduplicate.insert_size')
     results = get_qc(app.adapter, year=year, metric_path=metric_path)
@@ -53,4 +55,3 @@ def qc_scatter(year):
                            version=__version__,
                            year_of_interest=year,
                            years=YEARS)
-

--- a/vogue/server/endpoints/covid.py
+++ b/vogue/server/endpoints/covid.py
@@ -21,6 +21,7 @@ def microsalt_qc_time(year):
     results = microsalt_get_qc_time(app.adapter, year=year, metric_path=metric_path, category='cov')
     return render_template('microsalt_qc_time.html',
                            results=results['data'],
+                           outliers=results['outliers'],
                            categories=results['labels'],
                            mean=results['mean'],
                            selected_group=metric_path.split('.')[0],

--- a/vogue/server/endpoints/covid.py
+++ b/vogue/server/endpoints/covid.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+from flask import url_for, redirect, render_template, request, Blueprint, current_app
+
+from vogue.constants.constants import *
+from vogue.server.utils import *
+from vogue.server.utils.covid import get_qc
+from vogue import __version__
+
+app = current_app
+covid_blueprint = Blueprint('covid', __name__)
+
+
+HEADER= 'Microsalt Covid'
+
+
+@covid_blueprint.route('/Bioinfo/Covid/qc_time/<year>', methods=['GET', 'POST'])
+def microsalt_qc_time(year):
+    metric_path = request.form.get('qc_metric',
+                                   'picard_markduplicate.insert_size')
+    results = microsalt_get_qc_time(app.adapter, year=year, metric_path=metric_path, category='cov')
+    return render_template('microsalt_qc_time.html',
+                           results=results['data'],
+                           categories=results['labels'],
+                           mean=results['mean'],
+                           selected_group=metric_path.split('.')[0],
+                           selected_metric=metric_path.split('.')[1],
+                           header=HEADER,
+                           page_id='microsalt_cov_qc_time',
+                           page_url='covid.microsalt_qc_time',
+                           version=__version__,
+                           year_of_interest=year,
+                           MICROSALT=MICROSALT,
+                           years=YEARS)
+
+
+
+@covid_blueprint.route('/Bioinfo/Covid/qc_time_scatter/<year>', methods=['GET', 'POST'])
+def qc_scatter(year):
+    metric_path = request.form.get('qc_metric',
+                                   'picard_markduplicate.insert_size')
+    results = get_qc(app.adapter, year=year, metric_path=metric_path)
+
+    return render_template('cov_qc_scatter.html',
+                           results=results,
+                           MICROSALT=MICROSALT,
+                           selected_group=metric_path.split('.')[0],
+                           metric=metric_path.split('.')[1],
+                           header=HEADER,
+                           page_id='cov_qc_scatter',
+                           page_url='covid.qc_scatter',
+                           version=__version__,
+                           year_of_interest=year,
+                           years=YEARS)
+

--- a/vogue/server/templates/cov_qc_scatter.html
+++ b/vogue/server/templates/cov_qc_scatter.html
@@ -1,95 +1,105 @@
 {% extends 'layout.html' %}
 {% block body %}
-{% include 'header.html' %}
-<div class="container-fluid">
-    <div class="row">
-        {% include 'navigation.html' %}
-        <main role="main" class="col-md-9 ml-sm-auto col-lg-10 px-4">
-            {% include 'header_section.html' %}
-            <div class="card">
-                <div class="card-body">
-                    <div class="row">
-                        <div class="btn mb-2 mb-md-0">
-                            <form action="{{ url_for(page_url , year=year_of_interest) }}" method="POST">
-                                <select id="metric" name="metric" class="form-control form-control-sm"
-                                    placeholder=".form-control-sm" required onchange="this.form.submit()">
-                                    {% for group in MICROSALT %}
-                                    <optgroup label="{{group.capitalize().replace('_', ' ')}}">
-                                        {% for metric in MICROSALT[group] %}
-                                        <option value="{{group}}.{{ metric }}"
-                                            {{ 'selected' if metric == selected_metric }}>
-                                            {{ metric.capitalize().replace('_', ' ')}}
-                                        </option>
+    {% include 'header.html' %}
+    <div class="container-fluid">
+        <div class="row">
+            {% include 'navigation.html' %}
+            <main role="main" class="col-md-9 ml-sm-auto col-lg-10 px-4">
+                {% include 'header_section.html' %}
+                <div class="card">
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="btn mb-2 mb-md-0">
+                                <form action="{{ url_for(page_url , year=year_of_interest) }}" method="POST">
+                                    <select id="metric" name="metric" class="form-control form-control-sm"
+                                            placeholder=".form-control-sm" required onchange="this.form.submit()">
+                                        {% for group in MICROSALT %}
+                                            <optgroup label="{{ group.capitalize().replace('_', ' ') }}">
+                                            {% for metric in MICROSALT[group] %}
+                                                <option value="{{ group }}.{{ metric }}"
+                                                        {{ 'selected' if metric == selected_metric }}>
+                                                    {{ metric.capitalize().replace('_', ' ') }}
+                                                </option>
+                                            {% endfor %}
                                         {% endfor %}
-                                        {% endfor %}
-                                </select>
-                            </form>
-                        </div>
-                        <div class="col-lg-12">
-                            <div id="run_info"></div>
+                                    </select>
+                                </form>
+                            </div>
+                            <div class="col-lg-12">
+                                <div id="sample_info"></div>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-        </main>
+            </main>
+        </div>
     </div>
-</div>
 
 
 
-<script>
-    var series = []
-    {% for group in results %}
+    <script>
+        var series = []
+        {% for group in results %}
 
-    var data = []
-    {% for date, value, run_id in results[group] %}
-    // in this context january is 0, february 1,..., december 11 thereby date.month-1
-    data.push({ 'x': Date.UTC({{ date.year }}, {{ date.month - 1 }}, {{ date.day }}), 'y': {{ value }}, 'name': {{ run_id | tojson }}, 'date': "{{ date.day}}/{{ date.month }}" } )
-    {% endfor %}
-    series.push({
-        findNearestPointBy: 'xy',
-        name: "{{group}}",
-        data: data,
-        marker: { symbol: 'circle' }
-    })
-    {% endfor %}
-    Highcharts.chart('run_info', {
-        chart: { type: 'scatter' },
-        title: { text: '{{metric}} over Time' },
-        xAxis: {
-            type: 'datetime',
-            dateTimeLabelFormats: {
-                month: '%b',
-                year: '%b'
-            }
-        },
-        yAxis: { title: { text: {{ metric | tojson }} },
-        min: 0},
-        legend: {
-        title: {
-            text: 'Prep Method<br/><span style="font-size: 9px; color: #666; font-weight: normal">(Click to hide)</span>',
-            style: { fontStyle: 'italic' }
-        },
-        layout: 'vertical',
-        align: 'right',
-        verticalAlign: 'middle'
-    },
-        tooltip: {
-        formatter: function () {
-            return 'Run ID: <b>' + this.point.name + '</b> <br> {{metric}}: <b>' + this.y + '</b> <br>Received Date: <b>' + this.point.date + '</b>';
-        }
-    },
-        plotOptions: {
-        spline: {
-            marker: {
-                enabled: true,
-                radius: 2,
-                lineColor: '#666666',
-                lineWidth: 1
-            }
-        }
-    },
-        series: series
-});
-</script>
+            var data = []
+            {% for date, value, sample_id in results[group] %}
+                // in this context january is 0, february 1,..., december 11 thereby date.month-1
+                data.push({
+                    'x': Date.UTC({{ date.year }}, {{ date.month - 1 }}, {{ date.day }}),
+                    'y': {{ value }},
+                    'name': {{ sample_id | tojson }},
+                    'date': "{{ date.day}}/{{ date.month }}"
+                })
+            {% endfor %}
+            series.push({
+                findNearestPointBy: 'xy',
+                name: "{{group}}",
+                data: data,
+                marker: {symbol: 'circle'}
+            })
+        {% endfor %}
+        Highcharts.chart('sample_info', {
+            chart: {type: 'scatter'},
+            title: {text: '{{metric}} over Time'},
+            xAxis: {
+                type: 'datetime',
+                dateTimeLabelFormats: {
+                    month: '%b',
+                    year: '%b'
+                }
+            },
+            yAxis: {
+                title: {text: {{ metric | tojson }}},
+                min: 0
+            },
+            legend: {
+                title: {
+                    text: 'Prep Method<br/><span style="font-size: 9px; color: #666; font-weight: normal">(Click to hide)</span>',
+                    style: {fontStyle: 'italic'}
+                },
+                layout: 'vertical',
+                align: 'right',
+                verticalAlign: 'middle'
+            },
+            tooltip: {
+                formatter: function () {
+                    return 'sample ID: <b>' + this.point.name + '</b> <br> {{metric}}: <b>' + this.y + '</b> <br>Prep Date: <b>' + this.point.date + '</b>';
+                }
+            },
+            plotOptions: {
+                series: {
+                    stickyTracking: false
+                },
+                spline: {
+                    marker: {
+                        enabled: true,
+                        radius: 2,
+                        lineColor: '#666666',
+                        lineWidth: 1
+                    }
+                }
+            },
+            series: series
+        });
+    </script>
 {% endblock %}

--- a/vogue/server/templates/cov_qc_scatter.html
+++ b/vogue/server/templates/cov_qc_scatter.html
@@ -1,0 +1,95 @@
+{% extends 'layout.html' %}
+{% block body %}
+{% include 'header.html' %}
+<div class="container-fluid">
+    <div class="row">
+        {% include 'navigation.html' %}
+        <main role="main" class="col-md-9 ml-sm-auto col-lg-10 px-4">
+            {% include 'header_section.html' %}
+            <div class="card">
+                <div class="card-body">
+                    <div class="row">
+                        <div class="btn mb-2 mb-md-0">
+                            <form action="{{ url_for(page_url , year=year_of_interest) }}" method="POST">
+                                <select id="metric" name="metric" class="form-control form-control-sm"
+                                    placeholder=".form-control-sm" required onchange="this.form.submit()">
+                                    {% for group in MICROSALT %}
+                                    <optgroup label="{{group.capitalize().replace('_', ' ')}}">
+                                        {% for metric in MICROSALT[group] %}
+                                        <option value="{{group}}.{{ metric }}"
+                                            {{ 'selected' if metric == selected_metric }}>
+                                            {{ metric.capitalize().replace('_', ' ')}}
+                                        </option>
+                                        {% endfor %}
+                                        {% endfor %}
+                                </select>
+                            </form>
+                        </div>
+                        <div class="col-lg-12">
+                            <div id="run_info"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </main>
+    </div>
+</div>
+
+
+
+<script>
+    var series = []
+    {% for group in results %}
+
+    var data = []
+    {% for date, value, run_id in results[group] %}
+    // in this context january is 0, february 1,..., december 11 thereby date.month-1
+    data.push({ 'x': Date.UTC({{ date.year }}, {{ date.month - 1 }}, {{ date.day }}), 'y': {{ value }}, 'name': {{ run_id | tojson }}, 'date': "{{ date.day}}/{{ date.month }}" } )
+    {% endfor %}
+    series.push({
+        findNearestPointBy: 'xy',
+        name: "{{group}}",
+        data: data,
+        marker: { symbol: 'circle' }
+    })
+    {% endfor %}
+    Highcharts.chart('run_info', {
+        chart: { type: 'scatter' },
+        title: { text: '{{metric}} over Time' },
+        xAxis: {
+            type: 'datetime',
+            dateTimeLabelFormats: {
+                month: '%b',
+                year: '%b'
+            }
+        },
+        yAxis: { title: { text: {{ metric | tojson }} },
+        min: 0},
+        legend: {
+        title: {
+            text: 'Prep Method<br/><span style="font-size: 9px; color: #666; font-weight: normal">(Click to hide)</span>',
+            style: { fontStyle: 'italic' }
+        },
+        layout: 'vertical',
+        align: 'right',
+        verticalAlign: 'middle'
+    },
+        tooltip: {
+        formatter: function () {
+            return 'Run ID: <b>' + this.point.name + '</b> <br> {{metric}}: <b>' + this.y + '</b> <br>Received Date: <b>' + this.point.date + '</b>';
+        }
+    },
+        plotOptions: {
+        spline: {
+            marker: {
+                enabled: true,
+                radius: 2,
+                lineColor: '#666666',
+                lineWidth: 1
+            }
+        }
+    },
+        series: series
+});
+</script>
+{% endblock %}

--- a/vogue/server/templates/microsalt_qc_time.html
+++ b/vogue/server/templates/microsalt_qc_time.html
@@ -10,7 +10,7 @@
                 <div class="card-body">
                     <div class="row">
                         <div class="btn mb-2 mb-md-0">
-                            <form action="{{ url_for('server.microsalt_qc_time' , year=year_of_interest) }}"
+                            <form action="{{ url_for(page_url , year=year_of_interest) }}"
                                 method="POST">
                                 <select name="qc_metric" class="form-control form-control-sm"
                                     placeholder=".form-control-sm" required onchange="this.form.submit()">

--- a/vogue/server/templates/microsalt_qc_time.html
+++ b/vogue/server/templates/microsalt_qc_time.html
@@ -69,22 +69,29 @@
     }
     }] },
         legend: { enabled: false },
-        tooltip: { headerFormat: '<em>Experiment No {point.key}</em><br/>' },
         plotOptions: {
-        series: { connectNulls: true },
-        spline: {
-            marker: {
-                radius: 4,
-                lineColor: '#666666',
-                lineWidth: 1
-            }
+        series: {
+            stickyTracking: false
         }
     },
         series: [{
             name: '{{selected_metric}}',
-            data: data,
-            marker: { symbol: 'circle' }
-        }] 
+            data: data},
+        {
+        name: 'Outliers',
+        color: Highcharts.getOptions().colors[0],
+        type: 'scatter',
+        data: {{ outliers |tojson}},
+        marker: {
+            radius: 2,
+            fillColor: 'white',
+            lineWidth: 1,
+            lineColor: Highcharts.getOptions().colors[0]
+        },
+        tooltip: {
+            pointFormat: 'Sample: {point.name} <br/> Value: {point.y}'
+        }
+    }]
 });
 
 </script>

--- a/vogue/server/templates/navigation.html
+++ b/vogue/server/templates/navigation.html
@@ -87,6 +87,17 @@
                   </li>
                 </ul>
               </li>
+            <li class="dropdown-item btn-sm dropdown-submenu">
+                <a href="#" data-toggle="dropdown" class="dropdown-toggle">Covid</a>
+                <ul class="dropdown-menu">
+                  <li class="dropdown-item btn-sm">
+                    <a class="dropdown-toggle-sub-menue" href="{{ url_for('covid.microsalt_qc_time' , year=year_of_interest) }}">QC over time - Box plot</a>
+                  </li>
+                    <li class="dropdown-item btn-sm">
+                    <a class="dropdown-toggle-sub-menue" href="{{ url_for('covid.qc_scatter' , year=year_of_interest) }}">QC over time - Scatter plot</a>
+                  </li>
+                </ul>
+              </li>
         </ul>
       </li>
       <li class="nav-item dropright">

--- a/vogue/server/utils/covid.py
+++ b/vogue/server/utils/covid.py
@@ -1,77 +1,70 @@
 #!/usr/bin/env python
 
-from mongo_adapter import get_client
-from datetime import datetime as dt
-import numpy as np
-from vogue.constants.constants import (MONTHS, TEST_SAMPLES, MIP_DNA_PICARD,
-                                       LANE_UDFS)
-from statistics import mean
-
-
 def get_qc(adapter, year: int, metric_path: str) -> dict:
-    """Prepares data for a plot Q30 values for diferent runs over time"""
+    """Prepares data for covid scatter plot"""
+
     metric = metric_path.split('.')[1]
 
     pipe = [
-    {
-        '$match': {
-            'microsalt': {
-                '$exists': 'True'
+        {
+            '$match': {
+                'microsalt': {
+                    '$exists': 'True'
+                }
             }
-        }
-    }, {
-        '$lookup': {
-            'from': 'sample',
-            'localField': '_id',
-            'foreignField': '_id',
-            'as': 'sample_info'
-        }
-    }, {
-        '$unwind': {
-            'path': '$sample_info'
-        }
-    }, {
-        '$match': {
-            'sample_info.category': {
-                '$eq': 'cov'
-            },
-            'sample_info.prepared_date': {
-                '$exists': 'True'
-            },
-            'sample_info.prep_method': {
-                '$exists': 'True'
+        }, {
+            '$lookup': {
+                'from': 'sample',
+                'localField': '_id',
+                'foreignField': '_id',
+                'as': 'sample_info'
             }
-        }
-    }, {
-        '$project': {
-            'year': {
-                '$year': '$sample_info.prepared_date'
-            },
-            'prep_method': '$sample_info.prep_method',
-            'date': '$sample_info.prepared_date',
-            metric: f"$microsalt.{metric_path}"
-        }
-    }, {
-        '$match': {
-            'year': {
-                '$eq': int(year)
+        }, {
+            '$unwind': {
+                'path': '$sample_info'
             }
-        }
-    }, {
-        '$group': {
-            '_id': {
-                'prep_method': 'prep_method'
-            },
-            'data': {
-                '$push': {
-                    metric: f"${metric}",
-                    'date': '$date',
-                    'id': '$_id'
+        }, {
+            '$match': {
+                'sample_info.category': {
+                    '$eq': 'cov'
+                },
+                'sample_info.prepared_date': {
+                    '$exists': 'True'
+                },
+                'sample_info.prep_method': {
+                    '$exists': 'True'
+                }
+            }
+        }, {
+            '$project': {
+                'year': {
+                    '$year': '$sample_info.prepared_date'
+                },
+                'prep_method': '$sample_info.prep_method',
+                'date': '$sample_info.prepared_date',
+                metric: f"$microsalt.{metric_path}"
+            }
+        }, {
+            '$match': {
+                'year': {
+                    '$eq': int(year)
+                }
+            }
+        }, {
+            '$group': {
+                '_id': {
+                    'prep_method': '$prep_method'
+                },
+                'data': {
+                    '$push': {
+                        metric: f"${metric}",
+                        'date': '$date',
+                        'id': '$_id'
+                    }
                 }
             }
         }
-    }
-]
+    ]
 
     aggregate_result = adapter.bioinfo_samples_aggregate(pipe)
     results = {}
@@ -79,7 +72,6 @@ def get_qc(adapter, year: int, metric_path: str) -> dict:
         group = group_data['_id']['prep_method']
         results[group] = []
         for sample in group_data['data']:
-            results[group].append([sample['date'],sample[metric], sample['id']])
-
+            results[group].append([sample['date'], sample[metric], sample['id']])
 
     return results

--- a/vogue/server/utils/covid.py
+++ b/vogue/server/utils/covid.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+from mongo_adapter import get_client
+from datetime import datetime as dt
+import numpy as np
+from vogue.constants.constants import (MONTHS, TEST_SAMPLES, MIP_DNA_PICARD,
+                                       LANE_UDFS)
+from statistics import mean
+
+
+def get_qc(adapter, year: int, metric_path: str) -> dict:
+    """Prepares data for a plot Q30 values for diferent runs over time"""
+    metric = metric_path.split('.')[1]
+
+    pipe = [
+    {
+        '$match': {
+            'microsalt': {
+                '$exists': 'True'
+            }
+        }
+    }, {
+        '$lookup': {
+            'from': 'sample',
+            'localField': '_id',
+            'foreignField': '_id',
+            'as': 'sample_info'
+        }
+    }, {
+        '$unwind': {
+            'path': '$sample_info'
+        }
+    }, {
+        '$match': {
+            'sample_info.category': {
+                '$eq': 'cov'
+            },
+            'sample_info.prepared_date': {
+                '$exists': 'True'
+            },
+            'sample_info.prep_method': {
+                '$exists': 'True'
+            }
+        }
+    }, {
+        '$project': {
+            'year': {
+                '$year': '$sample_info.prepared_date'
+            },
+            'prep_method': '$sample_info.prep_method',
+            'date': '$sample_info.prepared_date',
+            metric: f"$microsalt.{metric_path}"
+        }
+    }, {
+        '$match': {
+            'year': {
+                '$eq': int(year)
+            }
+        }
+    }, {
+        '$group': {
+            '_id': {
+                'prep_method': 'prep_method'
+            },
+            'data': {
+                '$push': {
+                    metric: f"${metric}",
+                    'date': '$date',
+                    'id': '$_id'
+                }
+            }
+        }
+    }
+]
+
+    aggregate_result = adapter.bioinfo_samples_aggregate(pipe)
+    results = {}
+    for group_data in aggregate_result:
+        group = group_data['_id']['prep_method']
+        results[group] = []
+        for sample in group_data['data']:
+            results[group].append([sample['date'],sample[metric], sample['id']])
+
+
+    return results

--- a/vogue/server/utils/utils.py
+++ b/vogue/server/utils/utils.py
@@ -398,7 +398,6 @@ def instrument_info(adapter, year: int, metric: str) -> dict:
     }]
 
     aggregate_result = adapter.flowcells_aggregate(pipe)
-
     for result in aggregate_result:
         group = result['_id']['instrument']
         for plot_name in LANE_UDFS:
@@ -411,7 +410,7 @@ def instrument_info(adapter, year: int, metric: str) -> dict:
                     data.append([date, value, run_id])
             if data:
                 instruments['data'][plot_name][group] = {'data': data}
-
+    print(instruments)
     return instruments
 
 
@@ -602,7 +601,7 @@ def microsalt_get_strain_st(adapter, year: int) -> dict:
     return plot_data
 
 
-def microsalt_get_qc_time(adapter, year: int, metric_path: str) -> dict:
+def microsalt_get_qc_time(adapter, year: int, metric_path: str, category: str) -> dict:
     """Build aggregation pipeline to get information for microsalt qc data over time.
     """
     metric = metric_path.split('.')[1]
@@ -625,6 +624,7 @@ def microsalt_get_qc_time(adapter, year: int, metric_path: str) -> dict:
         }
     }, {
         '$match': {
+            'sample_info.category': {'$eq': category},
             'sample_info.received_date': {
                 '$exists': 'True'
             }

--- a/vogue/server/utils/utils.py
+++ b/vogue/server/utils/utils.py
@@ -681,8 +681,8 @@ def microsalt_get_qc_time(adapter, year: int, metric_path: str, category: str) -
             q2 = round(np.median(values), 2)
             q3 = round(np.percentile(values, 75), 2)
             iqr = q3 - q1
-            maximum = q3 + iqr * 0.5
-            minimum = q1 - iqr * 0.5
+            maximum = q3 + iqr * 1.5
+            minimum = q1 - iqr * 1.5
             outliers.extend([{'x': m[0] - 1, 'y': s[metric], 'name': s['id']} for s in samples if
                              minimum > s[metric] or s[metric] > maximum])
             means.append(np.mean(values))

--- a/vogue/server/views.py
+++ b/vogue/server/views.py
@@ -13,7 +13,6 @@ blueprint = Blueprint('server', __name__)
 @blueprint.route('/', methods=['GET', 'POST'])
 def index():
     year = request.form.get('year', str(THIS_YEAR))
-
     if request.form.get('page') == 'turn_around_times':
         return redirect(url_for('server.turn_around_times', year=year))
     if request.form.get('page') == 'samples':
@@ -40,6 +39,10 @@ def index():
         return redirect(url_for('server.microsalt_untyped', year=year))
     if request.form.get('page') == 'microsalt_st_time':
         return redirect(url_for('server.microsalt_st_time', year=year))
+    if request.form.get('page') == 'microsalt_cov_qc_time':
+        return redirect(url_for('covid.microsalt_qc_time', year=year))
+    if request.form.get('page') == 'cov_qc_scatter':
+        return redirect(url_for('covid.qc_scatter', year=year))
     if request.form.get('page') == 'genotype_plate':
         return redirect(url_for('server.genotype_plate'))
     if request.form.get('page') == 'reagent_labels':
@@ -252,6 +255,7 @@ def balsamic(year):
                            years=YEARS)
 
 
+
 @blueprint.route('/Bioinfo/Microbial/strain_st/<year>',
                  methods=['GET', 'POST'])
 def microsalt_strain_st(year):
@@ -275,7 +279,7 @@ def microsalt_strain_st(year):
 def microsalt_qc_time(year):
     metric_path = request.form.get('qc_metric',
                                    'picard_markduplicate.insert_size')
-    results = microsalt_get_qc_time(app.adapter, year, metric_path)
+    results = microsalt_get_qc_time(app.adapter, year=year, metric_path=metric_path, category='mic')
 
     return render_template('microsalt_qc_time.html',
                            results=results['data'],
@@ -284,11 +288,15 @@ def microsalt_qc_time(year):
                            selected_group=metric_path.split('.')[0],
                            selected_metric=metric_path.split('.')[1],
                            header='Microsalt',
+                           page_url='server.microsalt_qc_time',
                            page_id='microsalt_qc_time',
                            version=__version__,
                            year_of_interest=year,
                            MICROSALT=MICROSALT,
                            years=YEARS)
+
+
+
 
 
 @blueprint.route('/Bioinfo/Microbial/untyped/<year>', methods=['GET', 'POST'])

--- a/vogue/server/views.py
+++ b/vogue/server/views.py
@@ -283,6 +283,7 @@ def microsalt_qc_time(year):
 
     return render_template('microsalt_qc_time.html',
                            results=results['data'],
+                           outliers = results['outliers'],
                            categories=results['labels'],
                            mean=results['mean'],
                            selected_group=metric_path.split('.')[0],


### PR DESCRIPTION
- Adding new tab for covid plots
- Separating covid samples from micro samples (covid sampkles are no longer part of micro plots. Micro samples are not part of covid plots)
- Made a new scatter plot for covid samples grouped by prep method
- Added outliers to the micro_qc over time plot.


**Review:**
- [ ] code approved by
- [x] tests executed by @mayabrandi 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!


This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
