### PR TITLE
release v1.2.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,12 @@
+[bumpversion]
+current_version = 1.1.6
+commit = True
+tag = True
+tag_name = v{new_version}
+
+[bumpversion:file:vogue/__init__.py ]
+
+[bumpversion:file:README.rst]
+
+search = {current_version}
+replace = {new_version}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 This change log will document the notable changes to this project in this file and it is following [Semantic Versioning](https://semver.org/)
 
-## [x.x.x]
+## [1.2.0]
 
 ### Fixed
 - Bug - ST-total - Samples with missing sequence type showed up as a bar without name.
 - Adding new lims development wf
+- Bug - mip-dna as an acceptable input
 
 ## [1.1.6]
 


### PR DESCRIPTION
## [1.2.0]

### Fixed
- Bug - ST-total - Samples with missing sequence type showed up as a bar without name.
- Adding new lims development wf
- Bug - mip-dna as an acceptable input

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [X] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
