### PR TITLE
Version 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This change log will document the notable changes to this project in this file and it is following [Semantic Versioning](https://semver.org/)
 
-## [x.x.x]
+## [1.2.1]
 
 ### Changed
 - Separated server blueprint into several blueprints

--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,10 @@ Steps to make a new release:
 
 1) Create a release branch from master named ``version_X.X.X`` 
 2) Update change log with the new version.
-3) Use ``bumpversion`` to change version accordingly: ``bumpversion major`` or ``bumpversion minor`` or ``bumpversion patch``
-4) Make a PR to master, 
+3) Make a PR to master, 
+4) Merge release PR into master
+5) Use ``bumpversion`` to change version accordingly: ``bumpversion major`` or ``bumpversion minor`` or ``bumpversion patch``
+6) Do ``git push`` and ``git push --tags``
 
 .. code-block::
 

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Steps to make a new release:
 
 1) Create a release branch from master named ``version_X.X.X`` 
 2) Update change log with the new version.
-3) Update vogue/\ **init**.py with the new version.
+3) Use ``bumpversion`` to change version accordingly: ``bumpversion major`` or ``bumpversion minor`` or ``bumpversion patch``
 4) Make a PR to master, 
 
 .. code-block::


### PR DESCRIPTION
## Release branch

## [1.2.1]

### Changed
- Separated server blueprint into several blueprints
- Restructured the server/utiles to follow the follow the new bluepprint categories.
- Minor QoL changes

### Added
- Adding new tab for covid plots
- Separating covid samples from micro samples (covid sampkles are no longer part of micro plots. Micro samples are not part of covid plots)
- Made a new scatter plot for covid samples grouped by prep method
- Added outliers to the micro_qc over time plot.


This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [X] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
