### PR TITLE
release version 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This change log will document the notable changes to this project in this file a
 ### Changed
 - Bioinfo WGS, WES, and TGS view is zoomable
 - Picard HSMetrics' coverage range is increased to 1000X
+- Hardcode dependencies and their versions
+
+### Removed
+- multiqc and yapf from depedencies
 
  
 ## [1.3.0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
-click
-bumpversion
-pyyaml
-pymongo
+click==8.0.1
+bumpversion==0.6.0
+pyyaml==5.4.1
+pymongo==3.11.4
 genologics>=0.4.6
-yapf
-flask
-Flask-DebugToolbar
-coloredlogs
-mongo_adapter
-multiqc
-lzstring
-gunicorn
-werkzeug<1.0.0              # due to breaking changes in 1.0.0
+flask==1.1.2
+Flask-DebugToolbar==0.11.0
+coloredlogs==15.0.1
+mongo_adapter==0.3
+lzstring==1.0.4
+gunicorn==20.1.0
+werkzeug==0.16.1
+numpy==1.19.5
+python-dateutil==2.8.1


### PR DESCRIPTION
This PR is release version 1.3.1:

### Changed
- Bioinfo WGS, WES, and TGS view is zoomable
- Picard HSMetrics' coverage range is increased to 1000X
- Hardcode dependencies and their versions

### Removed
- multiqc and yapf from depedencies

**Review:**
- [ ] code approved by
- [X] tests executed by @hassanfa 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!


This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
